### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ sudo apt-get install build-essential cmake libibus-1.0-dev qt5-default qtdeclara
 On a Arch Linux / Arch Based system you can easily install them like this
 
 ```
-sudo pacman -Sy gcc make cmake qt5-base qtdeclarative libibus
+sudo pacman -Sy base-devel cmake qt5-base qtdeclarative libibus
 ```
 
 After you have installed required libraries and binaries. Clone this repository and change the directory to the cloned folder and issue the commands:


### PR DESCRIPTION
Using base-devel These are handily collected in the package group of basic compiling tools. Before you can actually build anything on Arch Machine you need to install this package. These package contains many necessary basic compiling tools including "make, gcc". This is package like "build-essential" on ubuntu/debian machine.