### PR TITLE
Layout viewer Resize FIX #76

### DIFF
--- a/src/frontend/LayoutViewer.cpp
+++ b/src/frontend/LayoutViewer.cpp
@@ -64,16 +64,6 @@ void LayoutViewer::on_viewNormal_clicked() {
   ui->labelImage->setPixmap(QPixmap::fromImage(image));
   ui->labelImage->adjustSize();
 
-
-  
-//  this->setFixedHeight(ui->labelImage->height() + ui->labelImage->y());
-//  this->setFixedWidth(ui->labelImage->width());
-
-
-//  ui->labelImage->setScaledContents(true);
-//  ui->labelImage->setFixedSize(780,360);
-
-
   ui->viewNormal->setChecked(true);
 }
 
@@ -83,13 +73,6 @@ void LayoutViewer::on_viewAltGr_clicked() {
     ui->labelImage->setPixmap(QPixmap::fromImage(image));
     ui->labelImage->adjustSize();
 
-
-//    ui->labelImage->setScaledContents(true);
-//    ui->labelImage->setFixedSize(780,361);
-
-
-    //    this->setFixedHeight(ui->labelImage->height() + ui->labelImage->y());
-//    this->setFixedWidth(ui->labelImage->width());
     ui->viewAltGr->setChecked(true);
   } else {
     ui->labelImage->setText("No image to display!");

--- a/src/frontend/LayoutViewer.cpp
+++ b/src/frontend/LayoutViewer.cpp
@@ -63,8 +63,17 @@ void LayoutViewer::on_viewNormal_clicked() {
   image.loadFromData(QByteArray::fromBase64(desc.image0));
   ui->labelImage->setPixmap(QPixmap::fromImage(image));
   ui->labelImage->adjustSize();
-  this->setFixedHeight(ui->labelImage->height() + ui->labelImage->y());
-  this->setFixedWidth(ui->labelImage->width());
+
+
+  
+//  this->setFixedHeight(ui->labelImage->height() + ui->labelImage->y());
+//  this->setFixedWidth(ui->labelImage->width());
+
+
+//  ui->labelImage->setScaledContents(true);
+//  ui->labelImage->setFixedSize(780,360);
+
+
   ui->viewNormal->setChecked(true);
 }
 
@@ -73,8 +82,14 @@ void LayoutViewer::on_viewAltGr_clicked() {
     image.loadFromData(QByteArray::fromBase64(desc.image1));
     ui->labelImage->setPixmap(QPixmap::fromImage(image));
     ui->labelImage->adjustSize();
-    this->setFixedHeight(ui->labelImage->height() + ui->labelImage->y());
-    this->setFixedWidth(ui->labelImage->width());
+
+
+//    ui->labelImage->setScaledContents(true);
+//    ui->labelImage->setFixedSize(780,361);
+
+
+    //    this->setFixedHeight(ui->labelImage->height() + ui->labelImage->y());
+//    this->setFixedWidth(ui->labelImage->width());
     ui->viewAltGr->setChecked(true);
   } else {
     ui->labelImage->setText("No image to display!");

--- a/src/frontend/LayoutViewer.ui
+++ b/src/frontend/LayoutViewer.ui
@@ -10,6 +10,18 @@
     <height>417</height>
    </rect>
   </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
+  <property name="minimumSize">
+   <size>
+    <width>0</width>
+    <height>0</height>
+   </size>
+  </property>
   <property name="windowTitle">
    <string>Dialog</string>
   </property>
@@ -84,6 +96,18 @@
    </item>
    <item row="1" column="0" colspan="7">
     <widget class="QLabel" name="labelImage">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>780</width>
+       <height>370</height>
+      </size>
+     </property>
      <property name="frameShape">
       <enum>QFrame::StyledPanel</enum>
      </property>

--- a/src/frontend/LayoutViewer.ui
+++ b/src/frontend/LayoutViewer.ui
@@ -6,12 +6,12 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>779</width>
-    <height>417</height>
+    <width>798</width>
+    <height>426</height>
    </rect>
   </property>
   <property name="sizePolicy">
-   <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+   <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
     <horstretch>0</horstretch>
     <verstretch>0</verstretch>
    </sizepolicy>
@@ -20,6 +20,12 @@
    <size>
     <width>0</width>
     <height>0</height>
+   </size>
+  </property>
+  <property name="maximumSize">
+   <size>
+    <width>798</width>
+    <height>426</height>
    </size>
   </property>
   <property name="windowTitle">


### PR DESCRIPTION
It fixes the resize issue mention in #76.  

It was happening because the size was hardcoded in `LayoutViewer.cpp` and the UI was changing every time `refreshLayoutViewer()` || `on_viewNormal_clicked()` || `on_viewAltGr_clicked()` was called. 
```cpp
// Previously Hardcoded code
this->setFixedHeight(ui->labelImage->height() + ui->labelImage->y());
this->setFixedWidth(ui->labelImage->width());
```

Solve: 
This can be done two way. First setting the size on the `LayoutViewer.cpp` or setting the size on the `LayoutViewer.ui`.  As this is a ui realtead work I opted to set the size on `LayoutViewer.ui`.

Here is the `cpp` code for future ref.

```cpp
// Set Fixed size for all LayoutViewer image
ui->labelImage->setScaledContents(true);
ui->labelImage->setFixedSize(780,370);
```