### PR TITLE
Commit the auxiliary text on Ctrl + B keypress

### DIFF
--- a/src/engine/ibus/ibus_engine.cpp
+++ b/src/engine/ibus/ibus_engine.cpp
@@ -78,9 +78,6 @@ void ibus_update_suggest(Suggestion suggest) {
     for (auto &str : suggestions.candidates) {
       IBusText *ctext = ibus_text_new_from_string((gchar *) str.c_str());
       ibus_lookup_table_append_candidate(table, ctext);
-      // Hide candidate labels // Hack learned from ibus-avro
-      IBusText *clabel = ibus_text_new_from_string("");
-      ibus_lookup_table_append_label(table, clabel);
     }
     // Previous selection
     candidateSel = (guint) suggestions.prevSelection;

--- a/src/engine/ibus/ibus_engine.cpp
+++ b/src/engine/ibus/ibus_engine.cpp
@@ -184,6 +184,12 @@ gboolean ibus_process_key_event_cb(IBusEngine *engine,
     }
   }
 
+  // Commit the preedit buffer when the `Ctrl + B` key is pressed.
+  if(kctrl && key == VC_B) {
+    ibus_commit();
+    return TRUE;
+  }
+
   // Send key events to the Layout
   Suggestion sgg = gLayout->getSuggestion(key, kshift, kctrl, kalt);
   // If we have processed the key, update suggestions

--- a/src/engine/ibus/ibus_engine.cpp
+++ b/src/engine/ibus/ibus_engine.cpp
@@ -98,15 +98,19 @@ void ibus_reset() {
   ibus_engine_hide_lookup_table(engine);
 }
 
+void commit_text(std::string text) {
+  IBusText *txt = ibus_text_new_from_string((gchar *) text.c_str());
+  ibus_engine_commit_text(engine, txt);
+  gLayout->candidateCommited(candidateSel);
+  ibus_reset();
+}
+
 void ibus_commit() {
   if (!suggestions.isEmpty()) {
-    std::string candidate = suggestions.candidates[candidateSel];
-    IBusText *txt = ibus_text_new_from_string((gchar *) candidate.c_str());
-    ibus_engine_commit_text(engine, txt);
-    gLayout->candidateCommited(candidateSel);
+    commit_text(suggestions.candidates[candidateSel]);
+  } else {
+    ibus_reset();
   }
-  ibus_reset();
-  candidateSel = 0;
 }
 
 void ibus_disconnected_cb(IBusBus *bus, gpointer user_data) {
@@ -182,8 +186,8 @@ gboolean ibus_process_key_event_cb(IBusEngine *engine,
   }
 
   // Commit the preedit buffer when the `Ctrl + B` key is pressed.
-  if(kctrl && key == VC_B) {
-    ibus_commit();
+  if(kctrl && key == VC_B && !suggestions.isEmpty()) {
+    commit_text(suggestions.auxiliaryText);
     return TRUE;
   }
 

--- a/src/engine/libengine/Layout.h
+++ b/src/engine/libengine/Layout.h
@@ -34,7 +34,7 @@
  *
  * @func isEmpty()
  * @return bool
- * @description Checks is there is any candidate in @candidates
+ * @description Checks is there any candidate available in @candidates
  */
 struct Suggestion {
   std::vector<std::string> candidates;

--- a/src/engine/libengine/MethodPhonetic.cpp
+++ b/src/engine/libengine/MethodPhonetic.cpp
@@ -617,6 +617,13 @@ Suggestion MethodPhonetic::getSuggestion(int key, bool shift, bool ctrl, bool al
       return suggested;
     }
     break; // Have a break
+  // Eat up Ctrl key
+  case VC_CONTROL:
+    if (EnglishT != "") {
+      handledKey = true;
+      return suggested;
+    }
+    break; // Have a break
   default:handledKey = false;
     return {};
   }


### PR DESCRIPTION
Commit the originally typed text or auxiliary text on <kbd>Ctrl + B</kbd> keypress.
![auxiliary text](https://user-images.githubusercontent.com/9459891/51424775-f6553a80-1bfc-11e9-901f-3f1c67d3fd53.gif)
