### PR TITLE
Make the commit raw text key customizable.

### DIFF
--- a/src/engine/ibus/ibus_engine.cpp
+++ b/src/engine/ibus/ibus_engine.cpp
@@ -186,7 +186,8 @@ gboolean ibus_process_key_event_cb(IBusEngine *engine,
   }
 
   // Commit the preedit buffer(raw text) when the user configured key is pressed.
-  if(kctrl && key == gLayout->commitRawTextKey() && !suggestions.isEmpty()) {
+  int rawTextKey = gLayout->commitRawTextKey();
+  if(kctrl && rawTextKey != 0 && key == rawTextKey && !suggestions.isEmpty()) {
     commit_text(suggestions.auxiliaryText);
     return TRUE;
   }

--- a/src/engine/ibus/ibus_engine.cpp
+++ b/src/engine/ibus/ibus_engine.cpp
@@ -185,8 +185,8 @@ gboolean ibus_process_key_event_cb(IBusEngine *engine,
     }
   }
 
-  // Commit the preedit buffer when the `Ctrl + B` key is pressed.
-  if(kctrl && key == VC_B && !suggestions.isEmpty()) {
+  // Commit the preedit buffer(raw text) when the user configured key is pressed.
+  if(kctrl && key == gLayout->commitRawTextKey() && !suggestions.isEmpty()) {
     commit_text(suggestions.auxiliaryText);
     return TRUE;
   }

--- a/src/engine/libengine/Layout.cpp
+++ b/src/engine/libengine/Layout.cpp
@@ -124,3 +124,7 @@ bool Layout::isCandidateWinHorizontal() {
 void Layout::updateEngine() {
   mth->updateEngine();
 }
+
+int Layout::commitRawTextKey() {
+  return gSettings->getCommitRaw();
+}

--- a/src/engine/libengine/Layout.h
+++ b/src/engine/libengine/Layout.h
@@ -140,11 +140,14 @@ public:
    * @index index of the candidate string that was commited */
   void candidateCommited(int index);
 
-  /* Checks is the candidate window horizontal */
+  /* Checks if the candidate window is horizontal */
   bool isCandidateWinHorizontal();
 
   /* Update internal suggestion making mechanism */
   void updateEngine();
+
+  /* Returns the user configured key for commiting raw text. */
+  int commitRawTextKey();
 };
 
 /* Global */

--- a/src/frontend/SettingsDialog.cpp
+++ b/src/frontend/SettingsDialog.cpp
@@ -28,6 +28,7 @@ SettingsDialog::SettingsDialog(QWidget *parent) :
 
   this->setFixedSize(QSize(this->width(), this->height()));
   ui->cmbOrientation->insertItems(0, {"Horizontal", "Vertical"});
+  ui->cmbRawTxt->addItem("None");
   rawTextKeys = {
     {"Ctrl + Q", VC_Q},
     {"Ctrl + W", VC_W},
@@ -70,7 +71,12 @@ void SettingsDialog::updateSettings() {
   ui->btnShowPrevWin->setChecked(gSettings->getShowCWPhonetic());
   ui->cmbOrientation->setCurrentIndex(gSettings->getCandidateWinHorizontal() ? 0 : 1);
   ui->btnCheckUpdate->setChecked(gSettings->getUpdateCheck());
-  ui->cmbRawTxt->setCurrentText(rawTextKeys.keys(gSettings->getCommitRaw()).first());
+  int rawTextKey = gSettings->getCommitRaw();
+  if(rawTextKey == 0) {
+    ui->cmbRawTxt->setCurrentText("None");
+  } else {
+    ui->cmbRawTxt->setCurrentText(rawTextKeys.keys(rawTextKey).first());
+  }
 }
 
 void SettingsDialog::on_buttonBox_accepted() {
@@ -78,7 +84,12 @@ void SettingsDialog::on_buttonBox_accepted() {
   gSettings->setShowCWPhonetic(ui->btnShowPrevWin->isChecked());
   gSettings->setCandidateWinHorizontal((ui->cmbOrientation->currentIndex() == 0));
   gSettings->setUpdateCheck(ui->btnCheckUpdate->isChecked());
-  gSettings->setCommitRaw(rawTextKeys.value(ui->cmbRawTxt->currentText()));
+  QString rawTextKey = ui->cmbRawTxt->currentText();
+  if(rawTextKey == "None") {
+    gSettings->setCommitRaw(0);
+  } else {
+    gSettings->setCommitRaw(rawTextKeys.value(rawTextKey));
+  }
 }
 
 void SettingsDialog::on_buttonBox_rejected() {

--- a/src/frontend/SettingsDialog.cpp
+++ b/src/frontend/SettingsDialog.cpp
@@ -19,6 +19,7 @@
 #include "SettingsDialog.h"
 #include "ui_SettingsDialog.h"
 #include "Settings.h"
+#include "keycode.h"
 
 SettingsDialog::SettingsDialog(QWidget *parent) :
     QDialog(parent),
@@ -27,6 +28,36 @@ SettingsDialog::SettingsDialog(QWidget *parent) :
 
   this->setFixedSize(QSize(this->width(), this->height()));
   ui->cmbOrientation->insertItems(0, {"Horizontal", "Vertical"});
+  rawTextKeys = {
+    {"Ctrl + Q", VC_Q},
+    {"Ctrl + W", VC_W},
+    {"Ctrl + E", VC_E},
+    {"Ctrl + R", VC_R},
+    {"Ctrl + T", VC_T},
+    {"Ctrl + Y", VC_Y},
+    {"Ctrl + U", VC_U},
+    {"Ctrl + I", VC_I},
+    {"Ctrl + O", VC_O},
+    {"Ctrl + P", VC_P},
+    {"Ctrl + A", VC_A},
+    {"Ctrl + S", VC_S},
+    {"Ctrl + D", VC_D},
+    {"Ctrl + F", VC_F},
+    {"Ctrl + G", VC_G},
+    {"Ctrl + H", VC_H},
+    {"Ctrl + J", VC_J},
+    {"Ctrl + K", VC_K},
+    {"Ctrl + L", VC_L},
+    {"Ctrl + Z", VC_Z},
+    {"Ctrl + X", VC_X},
+    {"Ctrl + C", VC_C},
+    {"Ctrl + V", VC_V},
+    {"Ctrl + B", VC_B},
+    {"Ctrl + V", VC_V},
+    {"Ctrl + N", VC_N},
+    {"Ctrl + M", VC_M},
+  };
+  ui->cmbRawTxt->addItems(rawTextKeys.keys());
   updateSettings();
 }
 
@@ -39,6 +70,7 @@ void SettingsDialog::updateSettings() {
   ui->btnShowPrevWin->setChecked(gSettings->getShowCWPhonetic());
   ui->cmbOrientation->setCurrentIndex(gSettings->getCandidateWinHorizontal() ? 0 : 1);
   ui->btnCheckUpdate->setChecked(gSettings->getUpdateCheck());
+  ui->cmbRawTxt->setCurrentText(rawTextKeys.keys(gSettings->getCommitRaw()).first());
 }
 
 void SettingsDialog::on_buttonBox_accepted() {
@@ -46,6 +78,7 @@ void SettingsDialog::on_buttonBox_accepted() {
   gSettings->setShowCWPhonetic(ui->btnShowPrevWin->isChecked());
   gSettings->setCandidateWinHorizontal((ui->cmbOrientation->currentIndex() == 0));
   gSettings->setUpdateCheck(ui->btnCheckUpdate->isChecked());
+  gSettings->setCommitRaw(rawTextKeys.value(ui->cmbRawTxt->currentText()));
 }
 
 void SettingsDialog::on_buttonBox_rejected() {

--- a/src/frontend/SettingsDialog.h
+++ b/src/frontend/SettingsDialog.h
@@ -20,6 +20,7 @@
 #define SETTINGSDIALOG_H
 
 #include <QDialog>
+#include <QMap>
 
 namespace Ui {
 class SettingsDialog;
@@ -49,6 +50,7 @@ private slots:
 
 private:
   Ui::SettingsDialog *ui;
+  QMap<QString, int> rawTextKeys;
 };
 
 #endif // SETTINGSDIALOG_H

--- a/src/frontend/SettingsDialog.ui
+++ b/src/frontend/SettingsDialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>483</width>
-    <height>224</height>
+    <width>475</width>
+    <height>260</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -19,111 +19,181 @@
   <property name="windowTitle">
    <string>Settings</string>
   </property>
-  <layout class="QGridLayout" name="gridLayout">
-   <property name="horizontalSpacing">
-    <number>40</number>
+  <widget class="QPushButton" name="btnClosePrevWin">
+   <property name="geometry">
+    <rect>
+     <x>364</x>
+     <y>10</y>
+     <width>101</width>
+     <height>33</height>
+    </rect>
    </property>
-   <property name="verticalSpacing">
-    <number>10</number>
+   <property name="text">
+    <string>Off</string>
    </property>
-   <item row="0" column="1">
-    <widget class="QPushButton" name="btnClosePrevWin">
-     <property name="text">
-      <string>Off</string>
-     </property>
-     <property name="checkable">
-      <bool>true</bool>
-     </property>
-    </widget>
-   </item>
-   <item row="3" column="1">
-    <widget class="QPushButton" name="btnCheckUpdate">
-     <property name="text">
-      <string>Off</string>
-     </property>
-     <property name="checkable">
-      <bool>true</bool>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="1">
-    <widget class="QComboBox" name="cmbOrientation"/>
-   </item>
-   <item row="3" column="0">
-    <widget class="QLabel" name="label_4">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="text">
-      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Automatically check for updates:&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="1">
-    <widget class="QPushButton" name="btnShowPrevWin">
-     <property name="text">
-      <string>Off</string>
-     </property>
-     <property name="checkable">
-      <bool>true</bool>
-     </property>
-    </widget>
-   </item>
-   <item row="4" column="0" colspan="2">
-    <widget class="QDialogButtonBox" name="buttonBox">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="0">
-    <widget class="QLabel" name="label">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="text">
-      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Enter/Return key only closes preview
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+  </widget>
+  <widget class="QPushButton" name="btnCheckUpdate">
+   <property name="geometry">
+    <rect>
+     <x>364</x>
+     <y>134</y>
+     <width>101</width>
+     <height>33</height>
+    </rect>
+   </property>
+   <property name="text">
+    <string>Off</string>
+   </property>
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+  </widget>
+  <widget class="QComboBox" name="cmbOrientation">
+   <property name="geometry">
+    <rect>
+     <x>364</x>
+     <y>98</y>
+     <width>101</width>
+     <height>25</height>
+    </rect>
+   </property>
+  </widget>
+  <widget class="QLabel" name="label_4">
+   <property name="geometry">
+    <rect>
+     <x>9</x>
+     <y>142</y>
+     <width>223</width>
+     <height>17</height>
+    </rect>
+   </property>
+   <property name="sizePolicy">
+    <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+     <horstretch>0</horstretch>
+     <verstretch>0</verstretch>
+    </sizepolicy>
+   </property>
+   <property name="text">
+    <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Automatically check for updates:&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+   </property>
+  </widget>
+  <widget class="QPushButton" name="btnShowPrevWin">
+   <property name="geometry">
+    <rect>
+     <x>364</x>
+     <y>54</y>
+     <width>101</width>
+     <height>33</height>
+    </rect>
+   </property>
+   <property name="text">
+    <string>Off</string>
+   </property>
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+  </widget>
+  <widget class="QDialogButtonBox" name="buttonBox">
+   <property name="geometry">
+    <rect>
+     <x>10</x>
+     <y>220</y>
+     <width>451</width>
+     <height>33</height>
+    </rect>
+   </property>
+   <property name="orientation">
+    <enum>Qt::Horizontal</enum>
+   </property>
+   <property name="standardButtons">
+    <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+   </property>
+  </widget>
+  <widget class="QLabel" name="label">
+   <property name="geometry">
+    <rect>
+     <x>9</x>
+     <y>18</y>
+     <width>315</width>
+     <height>17</height>
+    </rect>
+   </property>
+   <property name="sizePolicy">
+    <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+     <horstretch>0</horstretch>
+     <verstretch>0</verstretch>
+    </sizepolicy>
+   </property>
+   <property name="text">
+    <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Enter/Return key only closes preview
                             window:&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;
                         </string>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="0">
-    <widget class="QLabel" name="label_3">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="text">
-      <string>Suggestion List Orientation:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="0">
-    <widget class="QLabel" name="label_2">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="text">
-      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show Preview Window in Phonetic mode:&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-     </property>
-    </widget>
-   </item>
-  </layout>
+   </property>
+  </widget>
+  <widget class="QLabel" name="label_3">
+   <property name="geometry">
+    <rect>
+     <x>9</x>
+     <y>102</y>
+     <width>191</width>
+     <height>17</height>
+    </rect>
+   </property>
+   <property name="sizePolicy">
+    <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+     <horstretch>0</horstretch>
+     <verstretch>0</verstretch>
+    </sizepolicy>
+   </property>
+   <property name="text">
+    <string>Suggestion List Orientation:</string>
+   </property>
+  </widget>
+  <widget class="QLabel" name="label_2">
+   <property name="geometry">
+    <rect>
+     <x>9</x>
+     <y>62</y>
+     <width>280</width>
+     <height>17</height>
+    </rect>
+   </property>
+   <property name="sizePolicy">
+    <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+     <horstretch>0</horstretch>
+     <verstretch>0</verstretch>
+    </sizepolicy>
+   </property>
+   <property name="text">
+    <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show Preview Window in Phonetic mode:&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+   </property>
+  </widget>
+  <widget class="QLabel" name="label_5">
+   <property name="geometry">
+    <rect>
+     <x>10</x>
+     <y>180</y>
+     <width>241</width>
+     <height>17</height>
+    </rect>
+   </property>
+   <property name="text">
+    <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Commit Raw Text:&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+   </property>
+  </widget>
+  <widget class="QComboBox" name="cmbRawTxt">
+   <property name="geometry">
+    <rect>
+     <x>360</x>
+     <y>180</y>
+     <width>101</width>
+     <height>25</height>
+    </rect>
+   </property>
+  </widget>
  </widget>
  <resources/>
  <connections>

--- a/src/shared/Settings.cpp
+++ b/src/shared/Settings.cpp
@@ -161,3 +161,13 @@ bool Settings::getUpdateCheck() {
   setting->sync();
   return setting->value("settings/UpdateCheck", true).toBool();
 }
+
+void Settings::setCommitRaw(int key) {
+  setting->setValue("settings/CommitRaw", key);
+  setting->sync();
+}
+
+int Settings::getCommitRaw() {
+  setting->sync();
+  return setting->value("settings/CommitRaw", 0xA0C7).toInt(); // Default: Ctrl + T
+}

--- a/src/shared/Settings.h
+++ b/src/shared/Settings.h
@@ -83,6 +83,10 @@ public:
   void setUpdateCheck(bool b);
 
   bool getUpdateCheck();
+
+  void setCommitRaw(int key);
+
+  int getCommitRaw();
 };
 
 /* Global */


### PR DESCRIPTION
The default key has been changed into `Ctrl + T`.
Closes #93 

![commit-text-key](https://user-images.githubusercontent.com/9459891/53196758-f6ed5080-3642-11e9-9190-f3750019c946.png)
