### PR TITLE
Settings Dialog Redesign

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@ target_wrapper.*
 
 # QtCreator
 *.autosave
+*.stash
 
 # QtCreator Qml
 *.qmlproject.user

--- a/src/frontend/SettingsDialog.cpp
+++ b/src/frontend/SettingsDialog.cpp
@@ -60,6 +60,7 @@ SettingsDialog::SettingsDialog(QWidget *parent) :
     {"Ctrl + M", VC_M},
   };
   ui->cmbRawTxt->addItems(rawTextKeys.keys());
+  implementSignals();
   updateSettings();
 }
 
@@ -68,8 +69,48 @@ SettingsDialog::~SettingsDialog() {
   delete ui;
 }
 
+void SettingsDialog::implementSignals() {
+  // Phonetic Keyboard Layout Group.
+  connect(ui->btnShowPrevWin, &QPushButton::toggled, [=](bool checked) {
+    ui->btnShowPrevWin->setText(checked ? "On" : "Off");
+    // Control other Preview window related settings.
+    ui->btnClosePrevWin->setEnabled(checked);
+    ui->cmbOrientation->setEnabled(checked);
+    ui->cmbRawTxt->setEnabled(checked);
+    ui->btnACUpdate->setEnabled(checked);
+  });
+  connect(ui->btnClosePrevWin, &QPushButton::toggled, [=](bool checked) {
+    ui->btnClosePrevWin->setText(checked ? "On" : "Off");
+  });
+  connect(ui->btnACUpdate, &QPushButton::clicked, [=]() {
+    autoCorrectDialog->open();
+  });
+
+  // Fixed Keyboard Layout Group.
+  connect(ui->btnAutoVowel, &QPushButton::toggled, [=](bool checked) {
+    ui->btnAutoVowel->setText(checked ? "On" : "Off");
+  });
+  connect(ui->btnKarJoining, &QPushButton::toggled, [=](bool checked) {
+    ui->btnKarJoining->setText(checked ? "On" : "Off");
+  });
+  connect(ui->btnAutoChandra, &QPushButton::toggled, [=](bool checked) {
+    ui->btnAutoChandra->setText(checked ? "On" : "Off");
+  });
+  connect(ui->btnOldReph, &QPushButton::toggled, [=](bool checked) {
+    ui->btnOldReph->setText(checked ? "On" : "Off");
+  });
+  connect(ui->btnNumberpad, &QPushButton::toggled, [=](bool checked) {
+    ui->btnNumberpad->setText(checked ? "On" : "Off");
+  });
+
+  // General 
+  connect(ui->btnCheckUpdate, &QPushButton::toggled, [=](bool checked) {
+    ui->btnCheckUpdate->setText(checked ? "On" : "Off");
+  });
+}
+
 void SettingsDialog::updateSettings() {
-  // Phonetic Keyboard Layout
+  // Phonetic Keyboard Layout Group.
   ui->btnClosePrevWin->setChecked(gSettings->getEnterKeyClosesPrevWin());
   ui->btnShowPrevWin->setChecked(gSettings->getShowCWPhonetic());
   ui->cmbOrientation->setCurrentIndex(gSettings->getCandidateWinHorizontal() ? 0 : 1);
@@ -80,7 +121,7 @@ void SettingsDialog::updateSettings() {
     ui->cmbRawTxt->setCurrentText(rawTextKeys.keys(rawTextKey).first());
   }
 
-  // Fixed Keyboard Layout
+  // Fixed Keyboard Layout Group.
   ui->btnAutoVowel->setChecked(gSettings->getAutoVowelFormFixed());
   ui->btnAutoChandra->setChecked(gSettings->getAutoChandraPosFixed());
   ui->btnOldReph->setChecked(gSettings->getOldReph());
@@ -91,7 +132,7 @@ void SettingsDialog::updateSettings() {
 }
 
 void SettingsDialog::on_buttonBox_accepted() {
-  // Phonetic Keyboard Layout
+  // Phonetic Keyboard Layout Group.
   gSettings->setEnterKeyClosesPrevWin(ui->btnClosePrevWin->isChecked());
   gSettings->setShowCWPhonetic(ui->btnShowPrevWin->isChecked());
   gSettings->setCandidateWinHorizontal((ui->cmbOrientation->currentIndex() == 0));
@@ -102,7 +143,7 @@ void SettingsDialog::on_buttonBox_accepted() {
     gSettings->setCommitRaw(rawTextKeys.value(rawTextKey));
   }
 
-  // Fixed Keyboard Layout
+  // Fixed Keyboard Layout Group.
   gSettings->setAutoVowelFormFixed(ui->btnAutoVowel->isChecked());
   gSettings->setAutoChandraPosFixed(ui->btnAutoChandra->isChecked());
   gSettings->setOldReph(ui->btnOldReph->isChecked());
@@ -114,46 +155,4 @@ void SettingsDialog::on_buttonBox_accepted() {
 
 void SettingsDialog::on_buttonBox_rejected() {
   SettingsDialog::close();
-}
-
-void SettingsDialog::on_btnClosePrevWin_toggled(bool checked) {
-  ui->btnClosePrevWin->setText(checked ? "On" : "Off");
-}
-
-void SettingsDialog::on_btnShowPrevWin_toggled(bool checked) {
-  ui->btnShowPrevWin->setText(checked ? "On" : "Off");
-}
-
-void SettingsDialog::on_btnCheckUpdate_toggled(bool checked) {
-  ui->btnCheckUpdate->setText(checked ? "On" : "Off");
-}
-
-void SettingsDialog::on_btnAutoVowel_toggled(bool checked)
-{
-  ui->btnAutoVowel->setText(checked ? "On" : "Off");
-}
-
-void SettingsDialog::on_btnKarJoining_toggled(bool checked)
-{
-  ui->btnKarJoining->setText(checked ? "On" : "Off");
-}
-
-void SettingsDialog::on_btnAutoChandra_toggled(bool checked)
-{
-  ui->btnAutoChandra->setText(checked ? "On" : "Off");
-}
-
-void SettingsDialog::on_btnOldReph_toggled(bool checked)
-{
-  ui->btnOldReph->setText(checked ? "On" : "Off");
-}
-
-void SettingsDialog::on_btnNumberpad_toggled(bool checked)
-{
-  ui->btnNumberpad->setText(checked ? "On" : "Off");
-}
-
-void SettingsDialog::on_btnACUpdate_clicked()
-{
-  autoCorrectDialog->show();
 }

--- a/src/frontend/SettingsDialog.cpp
+++ b/src/frontend/SettingsDialog.cpp
@@ -19,11 +19,13 @@
 #include "SettingsDialog.h"
 #include "ui_SettingsDialog.h"
 #include "Settings.h"
+#include "AutoCorrectDialog.h"
 
 SettingsDialog::SettingsDialog(QWidget *parent) :
     QDialog(parent),
     ui(new Ui::SettingsDialog) {
   ui->setupUi(this);
+  autoCorrectDialog = new AutoCorrectDialog(this);
 
   this->setFixedSize(QSize(this->width(), this->height()));
   ui->cmbOrientation->insertItems(0, {"Horizontal", "Vertical"});
@@ -62,33 +64,52 @@ SettingsDialog::SettingsDialog(QWidget *parent) :
 }
 
 SettingsDialog::~SettingsDialog() {
+  delete autoCorrectDialog;
   delete ui;
 }
 
 void SettingsDialog::updateSettings() {
+  // Phonetic Keyboard Layout
   ui->btnClosePrevWin->setChecked(gSettings->getEnterKeyClosesPrevWin());
   ui->btnShowPrevWin->setChecked(gSettings->getShowCWPhonetic());
   ui->cmbOrientation->setCurrentIndex(gSettings->getCandidateWinHorizontal() ? 0 : 1);
-  ui->btnCheckUpdate->setChecked(gSettings->getUpdateCheck());
   int rawTextKey = gSettings->getCommitRaw();
   if(rawTextKey == 0) {
     ui->cmbRawTxt->setCurrentText("None");
   } else {
     ui->cmbRawTxt->setCurrentText(rawTextKeys.keys(rawTextKey).first());
   }
+
+  // Fixed Keyboard Layout
+  ui->btnAutoVowel->setChecked(gSettings->getAutoVowelFormFixed());
+  ui->btnAutoChandra->setChecked(gSettings->getAutoChandraPosFixed());
+  ui->btnOldReph->setChecked(gSettings->getOldReph());
+  ui->btnKarJoining->setChecked(gSettings->getTraditionalKarFixed());
+  ui->btnNumberpad->setChecked(gSettings->getNumberPadFixed());
+
+  ui->btnCheckUpdate->setChecked(gSettings->getUpdateCheck());
 }
 
 void SettingsDialog::on_buttonBox_accepted() {
+  // Phonetic Keyboard Layout
   gSettings->setEnterKeyClosesPrevWin(ui->btnClosePrevWin->isChecked());
   gSettings->setShowCWPhonetic(ui->btnShowPrevWin->isChecked());
   gSettings->setCandidateWinHorizontal((ui->cmbOrientation->currentIndex() == 0));
-  gSettings->setUpdateCheck(ui->btnCheckUpdate->isChecked());
   QString rawTextKey = ui->cmbRawTxt->currentText();
   if(rawTextKey == "None") {
     gSettings->setCommitRaw(0);
   } else {
     gSettings->setCommitRaw(rawTextKeys.value(rawTextKey));
   }
+
+  // Fixed Keyboard Layout
+  gSettings->setAutoVowelFormFixed(ui->btnAutoVowel->isChecked());
+  gSettings->setAutoChandraPosFixed(ui->btnAutoChandra->isChecked());
+  gSettings->setOldReph(ui->btnOldReph->isChecked());
+  gSettings->setTraditionalKarFixed(ui->btnKarJoining->isChecked());
+  gSettings->setNumberPadFixed(ui->btnNumberpad->isChecked());
+
+  gSettings->setUpdateCheck(ui->btnCheckUpdate->isChecked());
 }
 
 void SettingsDialog::on_buttonBox_rejected() {
@@ -105,4 +126,34 @@ void SettingsDialog::on_btnShowPrevWin_toggled(bool checked) {
 
 void SettingsDialog::on_btnCheckUpdate_toggled(bool checked) {
   ui->btnCheckUpdate->setText(checked ? "On" : "Off");
+}
+
+void SettingsDialog::on_btnAutoVowel_toggled(bool checked)
+{
+  ui->btnAutoVowel->setText(checked ? "On" : "Off");
+}
+
+void SettingsDialog::on_btnKarJoining_toggled(bool checked)
+{
+  ui->btnKarJoining->setText(checked ? "On" : "Off");
+}
+
+void SettingsDialog::on_btnAutoChandra_toggled(bool checked)
+{
+  ui->btnAutoChandra->setText(checked ? "On" : "Off");
+}
+
+void SettingsDialog::on_btnOldReph_toggled(bool checked)
+{
+  ui->btnOldReph->setText(checked ? "On" : "Off");
+}
+
+void SettingsDialog::on_btnNumberpad_toggled(bool checked)
+{
+  ui->btnNumberpad->setText(checked ? "On" : "Off");
+}
+
+void SettingsDialog::on_btnACUpdate_clicked()
+{
+  autoCorrectDialog->show();
 }

--- a/src/frontend/SettingsDialog.h
+++ b/src/frontend/SettingsDialog.h
@@ -55,6 +55,8 @@ namespace Ui {
 class SettingsDialog;
 }
 
+class AutoCorrectDialog;
+
 class SettingsDialog : public QDialog {
 Q_OBJECT
 
@@ -77,9 +79,22 @@ private slots:
 
   void on_btnCheckUpdate_toggled(bool checked);
 
+  void on_btnAutoVowel_toggled(bool checked);
+
+  void on_btnKarJoining_toggled(bool checked);
+
+  void on_btnAutoChandra_toggled(bool checked);
+
+  void on_btnOldReph_toggled(bool checked);
+
+  void on_btnNumberpad_toggled(bool checked);
+
+  void on_btnACUpdate_clicked();
+
 private:
   Ui::SettingsDialog *ui;
   QMap<QString, int> rawTextKeys;
+  AutoCorrectDialog *autoCorrectDialog;
 };
 
 #endif // SETTINGSDIALOG_H

--- a/src/frontend/SettingsDialog.h
+++ b/src/frontend/SettingsDialog.h
@@ -73,28 +73,12 @@ private slots:
 
   void on_buttonBox_rejected();
 
-  void on_btnClosePrevWin_toggled(bool checked);
-
-  void on_btnShowPrevWin_toggled(bool checked);
-
-  void on_btnCheckUpdate_toggled(bool checked);
-
-  void on_btnAutoVowel_toggled(bool checked);
-
-  void on_btnKarJoining_toggled(bool checked);
-
-  void on_btnAutoChandra_toggled(bool checked);
-
-  void on_btnOldReph_toggled(bool checked);
-
-  void on_btnNumberpad_toggled(bool checked);
-
-  void on_btnACUpdate_clicked();
-
 private:
   Ui::SettingsDialog *ui;
   QMap<QString, int> rawTextKeys;
   AutoCorrectDialog *autoCorrectDialog;
+
+  void implementSignals();
 };
 
 #endif // SETTINGSDIALOG_H

--- a/src/frontend/SettingsDialog.ui
+++ b/src/frontend/SettingsDialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>475</width>
-    <height>260</height>
+    <width>882</width>
+    <height>368</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -19,115 +19,379 @@
   <property name="windowTitle">
    <string>Settings</string>
   </property>
-  <layout class="QGridLayout" name="gridLayout">
-   <item row="0" column="0">
-    <widget class="QLabel" name="label">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="text">
-      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Enter/Return key only closes preview
-                            window:&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;
-                        </string>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="1">
-    <widget class="QPushButton" name="btnClosePrevWin">
-     <property name="text">
-      <string>Off</string>
-     </property>
-     <property name="checkable">
-      <bool>true</bool>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="0">
-    <widget class="QLabel" name="label_2">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="text">
-      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show Preview Window in Phonetic mode:&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="1">
-    <widget class="QPushButton" name="btnShowPrevWin">
-     <property name="text">
-      <string>Off</string>
-     </property>
-     <property name="checkable">
-      <bool>true</bool>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="0">
-    <widget class="QLabel" name="label_3">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="text">
-      <string>Suggestion List Orientation:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="1">
-    <widget class="QComboBox" name="cmbOrientation"/>
-   </item>
-   <item row="3" column="0">
-    <widget class="QLabel" name="label_4">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="text">
-      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Automatically check for updates:&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-     </property>
-    </widget>
-   </item>
-   <item row="3" column="1">
-    <widget class="QPushButton" name="btnCheckUpdate">
-     <property name="text">
-      <string>Off</string>
-     </property>
-     <property name="checkable">
-      <bool>true</bool>
-     </property>
-    </widget>
-   </item>
-   <item row="4" column="0">
-    <widget class="QLabel" name="label_5">
-     <property name="text">
-      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Commit Raw Text:&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-     </property>
-    </widget>
-   </item>
-   <item row="4" column="1">
-    <widget class="QComboBox" name="cmbRawTxt"/>
-   </item>
-   <item row="5" column="0" colspan="2">
-    <widget class="QDialogButtonBox" name="buttonBox">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
-     </property>
-    </widget>
-   </item>
-  </layout>
+  <widget class="QDialogButtonBox" name="buttonBox">
+   <property name="geometry">
+    <rect>
+     <x>360</x>
+     <y>330</y>
+     <width>166</width>
+     <height>25</height>
+    </rect>
+   </property>
+   <property name="orientation">
+    <enum>Qt::Horizontal</enum>
+   </property>
+   <property name="standardButtons">
+    <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+   </property>
+  </widget>
+  <widget class="QGroupBox" name="groupFixed">
+   <property name="geometry">
+    <rect>
+     <x>450</x>
+     <y>10</y>
+     <width>421</width>
+     <height>251</height>
+    </rect>
+   </property>
+   <property name="title">
+    <string>Fixed Keyboard Layout</string>
+   </property>
+   <widget class="QLabel" name="label_6">
+    <property name="geometry">
+     <rect>
+      <x>20</x>
+      <y>40</y>
+      <width>251</width>
+      <height>17</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>Automatic Vowel Forming:</string>
+    </property>
+   </widget>
+   <widget class="QPushButton" name="btnAutoChandra">
+    <property name="geometry">
+     <rect>
+      <x>300</x>
+      <y>80</y>
+      <width>101</width>
+      <height>25</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>Off</string>
+    </property>
+    <property name="checkable">
+     <bool>true</bool>
+    </property>
+   </widget>
+   <widget class="QPushButton" name="btnAutoVowel">
+    <property name="geometry">
+     <rect>
+      <x>300</x>
+      <y>40</y>
+      <width>101</width>
+      <height>25</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>Off</string>
+    </property>
+    <property name="checkable">
+     <bool>true</bool>
+    </property>
+   </widget>
+   <widget class="QLabel" name="label_7">
+    <property name="geometry">
+     <rect>
+      <x>20</x>
+      <y>80</y>
+      <width>261</width>
+      <height>17</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>Automatic Chandrabindu Position fix:</string>
+    </property>
+   </widget>
+   <widget class="QLabel" name="label_8">
+    <property name="geometry">
+     <rect>
+      <x>20</x>
+      <y>120</y>
+      <width>251</width>
+      <height>17</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>Old Style Reph:</string>
+    </property>
+   </widget>
+   <widget class="QPushButton" name="btnOldReph">
+    <property name="geometry">
+     <rect>
+      <x>300</x>
+      <y>120</y>
+      <width>101</width>
+      <height>25</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>Off</string>
+    </property>
+    <property name="checkable">
+     <bool>true</bool>
+    </property>
+   </widget>
+   <widget class="QLabel" name="label_9">
+    <property name="geometry">
+     <rect>
+      <x>20</x>
+      <y>160</y>
+      <width>251</width>
+      <height>17</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>Traditional Kar Joining:</string>
+    </property>
+   </widget>
+   <widget class="QPushButton" name="btnKarJoining">
+    <property name="geometry">
+     <rect>
+      <x>300</x>
+      <y>160</y>
+      <width>101</width>
+      <height>25</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>Off</string>
+    </property>
+    <property name="checkable">
+     <bool>true</bool>
+    </property>
+   </widget>
+   <widget class="QLabel" name="label_10">
+    <property name="geometry">
+     <rect>
+      <x>20</x>
+      <y>200</y>
+      <width>251</width>
+      <height>17</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>Bengali in NumberPad:</string>
+    </property>
+   </widget>
+   <widget class="QPushButton" name="btnNumberpad">
+    <property name="geometry">
+     <rect>
+      <x>300</x>
+      <y>200</y>
+      <width>101</width>
+      <height>25</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>Off</string>
+    </property>
+    <property name="checkable">
+     <bool>true</bool>
+    </property>
+   </widget>
+  </widget>
+  <widget class="QGroupBox" name="groupPhonetic">
+   <property name="geometry">
+    <rect>
+     <x>10</x>
+     <y>10</y>
+     <width>421</width>
+     <height>251</height>
+    </rect>
+   </property>
+   <property name="title">
+    <string>Phonetic Keyboard Layout</string>
+   </property>
+   <widget class="QComboBox" name="cmbOrientation">
+    <property name="geometry">
+     <rect>
+      <x>300</x>
+      <y>120</y>
+      <width>101</width>
+      <height>25</height>
+     </rect>
+    </property>
+   </widget>
+   <widget class="QPushButton" name="btnClosePrevWin">
+    <property name="geometry">
+     <rect>
+      <x>301</x>
+      <y>36</y>
+      <width>101</width>
+      <height>25</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>Off</string>
+    </property>
+    <property name="checkable">
+     <bool>true</bool>
+    </property>
+   </widget>
+   <widget class="QLabel" name="label_2">
+    <property name="geometry">
+     <rect>
+      <x>20</x>
+      <y>80</y>
+      <width>280</width>
+      <height>17</height>
+     </rect>
+    </property>
+    <property name="sizePolicy">
+     <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+      <horstretch>0</horstretch>
+      <verstretch>0</verstretch>
+     </sizepolicy>
+    </property>
+    <property name="text">
+     <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show Preview Window:&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+    </property>
+   </widget>
+   <widget class="QLabel" name="label_5">
+    <property name="geometry">
+     <rect>
+      <x>20</x>
+      <y>160</y>
+      <width>123</width>
+      <height>17</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Commit Raw Text:&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+    </property>
+   </widget>
+   <widget class="QComboBox" name="cmbRawTxt">
+    <property name="geometry">
+     <rect>
+      <x>300</x>
+      <y>160</y>
+      <width>101</width>
+      <height>25</height>
+     </rect>
+    </property>
+   </widget>
+   <widget class="QLabel" name="label_3">
+    <property name="geometry">
+     <rect>
+      <x>20</x>
+      <y>120</y>
+      <width>191</width>
+      <height>17</height>
+     </rect>
+    </property>
+    <property name="sizePolicy">
+     <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+      <horstretch>0</horstretch>
+      <verstretch>0</verstretch>
+     </sizepolicy>
+    </property>
+    <property name="text">
+     <string>Suggestion List Orientation:</string>
+    </property>
+   </widget>
+   <widget class="QLabel" name="label">
+    <property name="geometry">
+     <rect>
+      <x>20</x>
+      <y>40</y>
+      <width>271</width>
+      <height>17</height>
+     </rect>
+    </property>
+    <property name="sizePolicy">
+     <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+      <horstretch>0</horstretch>
+      <verstretch>0</verstretch>
+     </sizepolicy>
+    </property>
+    <property name="text">
+     <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Enter key only closes preview window:&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+    </property>
+   </widget>
+   <widget class="QPushButton" name="btnShowPrevWin">
+    <property name="geometry">
+     <rect>
+      <x>300</x>
+      <y>80</y>
+      <width>101</width>
+      <height>25</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>Off</string>
+    </property>
+    <property name="checkable">
+     <bool>true</bool>
+    </property>
+   </widget>
+   <widget class="QLabel" name="label_11">
+    <property name="geometry">
+     <rect>
+      <x>20</x>
+      <y>200</y>
+      <width>271</width>
+      <height>17</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>Auto Correct entries:</string>
+    </property>
+   </widget>
+   <widget class="QPushButton" name="btnACUpdate">
+    <property name="geometry">
+     <rect>
+      <x>300</x>
+      <y>200</y>
+      <width>101</width>
+      <height>25</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>Update</string>
+    </property>
+    <property name="checkable">
+     <bool>false</bool>
+    </property>
+   </widget>
+  </widget>
+  <widget class="QPushButton" name="btnCheckUpdate">
+   <property name="geometry">
+    <rect>
+     <x>500</x>
+     <y>290</y>
+     <width>101</width>
+     <height>25</height>
+    </rect>
+   </property>
+   <property name="text">
+    <string>Off</string>
+   </property>
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+  </widget>
+  <widget class="QLabel" name="label_4">
+   <property name="geometry">
+    <rect>
+     <x>270</x>
+     <y>290</y>
+     <width>231</width>
+     <height>17</height>
+    </rect>
+   </property>
+   <property name="sizePolicy">
+    <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+     <horstretch>0</horstretch>
+     <verstretch>0</verstretch>
+    </sizepolicy>
+   </property>
+   <property name="text">
+    <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Automatically check for updates:&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+   </property>
+  </widget>
  </widget>
  <resources/>
  <connections>

--- a/src/frontend/SettingsDialog.ui
+++ b/src/frontend/SettingsDialog.ui
@@ -218,8 +218,8 @@
    <widget class="QPushButton" name="btnClosePrevWin">
     <property name="geometry">
      <rect>
-      <x>301</x>
-      <y>36</y>
+      <x>300</x>
+      <y>80</y>
       <width>101</width>
       <height>25</height>
      </rect>
@@ -235,7 +235,7 @@
     <property name="geometry">
      <rect>
       <x>20</x>
-      <y>80</y>
+      <y>40</y>
       <width>280</width>
       <height>17</height>
      </rect>
@@ -296,7 +296,7 @@
     <property name="geometry">
      <rect>
       <x>20</x>
-      <y>40</y>
+      <y>80</y>
       <width>271</width>
       <height>17</height>
      </rect>
@@ -315,7 +315,7 @@
     <property name="geometry">
      <rect>
       <x>300</x>
-      <y>80</y>
+      <y>40</y>
       <width>101</width>
       <height>25</height>
      </rect>

--- a/src/frontend/TopBar.cpp
+++ b/src/frontend/TopBar.cpp
@@ -48,7 +48,6 @@ TopBar::TopBar(QWidget *parent) :
   aboutDialog = new AboutDialog(Q_NULLPTR);
   layoutViewer = new LayoutViewer(Q_NULLPTR);
   settingsDialog = new SettingsDialog(Q_NULLPTR);
-  autoCorrectDialog = new AutoCorrectDialog(Q_NULLPTR);
 
   ui->buttonIcon->installEventFilter(this);
 
@@ -66,7 +65,6 @@ TopBar::~TopBar() {
   delete layoutViewer;
   delete settingsDialog;
   delete aboutDialog;
-  delete autoCorrectDialog;
 
   delete gLayout;
   delete gSettings;
@@ -121,54 +119,14 @@ void TopBar::SetupPopupMenus() {
   RefreshLayouts();
   connect(layoutMenuInstall, SIGNAL(triggered()), this, SLOT(layoutMenuInstall_clicked()));
 
-  // Settings Popup Menu
-  settingsMenuFixedLayoutAutoVForm = new QAction("Enable \"Automatic Vowel Forming\"", this);
-  settingsMenuFixedLayoutAutoVForm->setCheckable(true);
-  settingsMenuFixedLayoutAutoVForm->setChecked(gSettings->getAutoVowelFormFixed());
-  connect(settingsMenuFixedLayoutAutoVForm, SIGNAL(triggered()), this,
-          SLOT(settingsMenuFixedLayoutAutoVForm_clicked()));
-
-  settingsMenuFixedLayoutAutoChandra = new QAction("Automatically fix \"Chandrabindu\" position", this);
-  settingsMenuFixedLayoutAutoChandra->setCheckable(true);
-  settingsMenuFixedLayoutAutoChandra->setChecked(gSettings->getAutoChandraPosFixed());
-  connect(settingsMenuFixedLayoutAutoChandra, SIGNAL(triggered()), this,
-          SLOT(settingsMenuFixedLayoutAutoChandra_clicked()));
-
-  settingsMenuFixedLayoutOldReph = new QAction("Old Style Reph", this);
-  settingsMenuFixedLayoutOldReph->setCheckable(true);
-  settingsMenuFixedLayoutOldReph->setChecked(gSettings->getOldReph());
-  connect(settingsMenuFixedLayoutOldReph, SIGNAL(triggered()), this, SLOT(settingsMenuFixedLayoutOldReph_clicked()));
-
-  settingsMenuFixedLayoutTraditionalKar = new QAction("Enable \"Traditional Kar Joining\"", this);
-  settingsMenuFixedLayoutTraditionalKar->setCheckable(true);
-  settingsMenuFixedLayoutTraditionalKar->setChecked(gSettings->getTraditionalKarFixed());
-  connect(settingsMenuFixedLayoutTraditionalKar, SIGNAL(triggered()), this,
-          SLOT(settingsMenuFixedLayoutTraditionalKar_clicked()));
-
-  settingsMenuFixedLayoutNumberPad = new QAction("Enable Bengali in NumberPad", this);
-  settingsMenuFixedLayoutNumberPad->setCheckable(true);
-  settingsMenuFixedLayoutNumberPad->setChecked(gSettings->getNumberPadFixed());
-  connect(settingsMenuFixedLayoutNumberPad, SIGNAL(triggered()), this,
-          SLOT(settingsMenuFixedLayoutNumberPad_clicked()));
-
-  settingsMenuFixedLayout = new QMenu("Fixed Keyboard Layout Options", this);
-  settingsMenuFixedLayout->addAction(settingsMenuFixedLayoutAutoVForm);
-  settingsMenuFixedLayout->addAction(settingsMenuFixedLayoutAutoChandra);
-  settingsMenuFixedLayout->addAction(settingsMenuFixedLayoutOldReph);
-  settingsMenuFixedLayout->addAction(settingsMenuFixedLayoutTraditionalKar);
-  settingsMenuFixedLayout->addAction(settingsMenuFixedLayoutNumberPad);
+  /* Settings Popup Menu
 
   settingsMenuShowDialog = new QAction("Settings", this);
   connect(settingsMenuShowDialog, SIGNAL(triggered()), this, SLOT(settingsMenuShowDialog_clicked()));
 
-  settingsMenuAutoCorrect = new QAction("Edit Phonetic AutoCorrect entries", this);
-  connect(settingsMenuAutoCorrect, SIGNAL(triggered()), this, SLOT(settingsMenuAutoCorrect_clicked()));
-
   settingsMenu = new QMenu(this);
-  settingsMenu->addMenu(settingsMenuFixedLayout);
-  settingsMenu->addAction(settingsMenuAutoCorrect);
-  settingsMenu->addSeparator();
   settingsMenu->addAction(settingsMenuShowDialog);
+  */
 
   // About Popup Menu
   aboutMenuLayout = new QAction("About current keyboard layout", this);
@@ -304,34 +262,11 @@ void TopBar::layoutMenuInstall_clicked() {
   RefreshLayouts();
 }
 
-void TopBar::settingsMenuFixedLayoutAutoVForm_clicked() {
-  gSettings->setAutoVowelFormFixed(settingsMenuFixedLayoutAutoVForm->isChecked());
-}
-
-void TopBar::settingsMenuFixedLayoutAutoChandra_clicked() {
-  gSettings->setAutoChandraPosFixed(settingsMenuFixedLayoutAutoChandra->isChecked());
-}
-
-void TopBar::settingsMenuFixedLayoutOldReph_clicked() {
-  gSettings->setOldReph(settingsMenuFixedLayoutOldReph->isChecked());
-}
-
-void TopBar::settingsMenuFixedLayoutTraditionalKar_clicked() {
-  gSettings->setTraditionalKarFixed(settingsMenuFixedLayoutTraditionalKar->isChecked());
-}
-
-void TopBar::settingsMenuFixedLayoutNumberPad_clicked() {
-  gSettings->setNumberPadFixed(settingsMenuFixedLayoutNumberPad->isChecked());
-}
-
-void TopBar::settingsMenuAutoCorrect_clicked() {
-  autoCorrectDialog->show();
-}
-
+/*
 void TopBar::settingsMenuShowDialog_clicked() {
   settingsDialog->updateSettings();
   settingsDialog->show();
-}
+}*/
 
 void TopBar::aboutMenuLayout_clicked() {
   layoutViewer->showLayoutInfoDialog();
@@ -417,9 +352,6 @@ void TopBar::on_buttonViewLayout_clicked() {
 }
 
 void TopBar::on_buttonSettings_clicked() {
-  QPoint point;
-  point = this->pos();
-  point.setX(point.x() + ui->buttonSettings->geometry().x());
-  point.setY(point.y() + this->height());
-  settingsMenu->exec(point);
+  settingsDialog->updateSettings();
+  settingsDialog->show();
 }

--- a/src/frontend/TopBar.h
+++ b/src/frontend/TopBar.h
@@ -64,19 +64,7 @@ private slots:
 
   void layoutMenuInstall_clicked();
 
-  void settingsMenuAutoCorrect_clicked();
-
-  void settingsMenuFixedLayoutAutoVForm_clicked();
-
-  void settingsMenuFixedLayoutAutoChandra_clicked();
-
-  void settingsMenuFixedLayoutOldReph_clicked();
-
-  void settingsMenuFixedLayoutTraditionalKar_clicked();
-
-  void settingsMenuFixedLayoutNumberPad_clicked();
-
-  void settingsMenuShowDialog_clicked();
+  //void settingsMenuShowDialog_clicked();
 
   void aboutMenuLayout_clicked();
 
@@ -109,7 +97,6 @@ private:
   AboutDialog *aboutDialog;
   LayoutViewer *layoutViewer;
   SettingsDialog *settingsDialog;
-  AutoCorrectDialog *autoCorrectDialog;
 
   /* Layout Popup Menu */
   QMenu *layoutMenu;
@@ -119,16 +106,9 @@ private:
   QAction *layoutMenuLayouts[MaxLayoutFiles];
   QActionGroup *layoutMenuLayoutsGroup;
   QAction *layoutMenuInstall;
-  /* Settings Popup Menu */
+  /* Settings Popup Menu 
   QMenu *settingsMenu;
-  QAction *settingsMenuAutoCorrect;
-  QAction *settingsMenuShowDialog;
-  QMenu *settingsMenuFixedLayout;
-  QAction *settingsMenuFixedLayoutAutoVForm;
-  QAction *settingsMenuFixedLayoutAutoChandra;
-  QAction *settingsMenuFixedLayoutOldReph;
-  QAction *settingsMenuFixedLayoutTraditionalKar;
-  QAction *settingsMenuFixedLayoutNumberPad;
+  QAction *settingsMenuShowDialog;*/
   /* About Popup Menu */
   QMenu *aboutMenu;
   QAction *aboutMenuLayout;


### PR DESCRIPTION
Merges Settings menu into Settings dialog!

Now the Settings Dialog looks like: :tada: 
![Settings_Dialog](https://user-images.githubusercontent.com/9459891/62660251-6061e100-b98f-11e9-9769-9ec510a443b9.png)

With this change, the Settings button in TopBar shows Settings dialog instead of showing a menu.

Closes #110 