### PR TITLE
update readme for PR #130

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -71,16 +71,55 @@ toc::[]
 
 == Installation
 
-WARNING: If you had installed OpenBangla Keyboard 1.2.0 or earlier version, please uninstall it first.
+IMPORTANT: If you had installed OpenBangla Keyboard 1.5.1 or earlier version, please uninstall it first.
 
-Make sure you have a **working internet connection**.
+First set up our repositories for your distro, then you can install normally with your package manager.
 
-Open your terminal and run this command on your shell:
+=== Ubuntu & derivatives
+Run these commands to set up our repository:
 ```bash
-bash -c "$(wget -nv -O- https://bit.ly/OBK-sh)"
+source /etc/os-release
+curl https://dl.bintray.com/openbangla/i/pub.key | sudo apt-key add -
+curl https://dl.bintray.com/openbangla/i/ubuntu.conf | sed "s/@NAME@/$UBUNTU_CODENAME/" | sudo tee /etc/apt/sources.list.d/openbangla.list
+sudo apt-get update
 ```
 
-Then use iBus UI or run `ibus-setup` to add and activate **OpenBangla Keyboard** as input method.
+=== Debian
+Run these commands to set up our repository:
+```bash
+source /etc/os-release
+curl https://dl.bintray.com/openbangla/i/pub.key | sudo apt-key add -
+curl https://dl.bintray.com/openbangla/i/debian.conf | sed "s/@NAME@/$VERSION_CODENAME/" | sudo tee /etc/apt/sources.list.d/openbangla.list
+sudo apt-get update
+```
+
+=== Fedora
+Run these commands to set up our repository:
+```bash
+sudp rpm --import https://dl.bintray.com/openbangla/i/pub.key
+curl https://dl.bintray.com/openbangla/i/fedora.conf | sudo tee /etc/yum.repos.d/openbangla.repo
+```
+
+=== Archlinux
+Run these commands to set up our repository:
+```bash
+sudo pacman-key -r 0x00F3092A45393EC8
+sudo pacman-key --lsign-key 0x00F3092A45393EC8
+curl https://dl.bintray.com/openbangla/i/archlinux.conf | sudo tee -a /etc/pacman.conf
+sudo pacman -Syy
+```
+
+=== Finally
+Done! Now you can use your package manager normally to get OpenBangla-Keyboard!
+```bash
+sudo apt-get install openbangla-keyboard
+sudo dnf install openbangla-keyboard
+sudo pacman -S openbangla-keyboard
+```
+
+You can also install by downloading necessary packages from our https://github.com/OpenBangla/OpenBangla-Keyboard/releases[Release] page
+
+After installation, use iBus UI or run `ibus-setup` to add and activate **OpenBangla Keyboard** as input method.
 
 After you have installed OpenBangla Keyboard, you may need to https://github.com/OpenBangla/OpenBangla-Keyboard/wiki/Configuring-Environment[configure your desktop environment].
 

--- a/README.adoc
+++ b/README.adoc
@@ -79,8 +79,8 @@ First set up our repositories for your distro, then you can install normally wit
 Run these commands to set up our repository:
 ```bash
 source /etc/os-release
-curl https://dl.bintray.com/openbangla/i/pub.key | sudo apt-key add -
-curl https://dl.bintray.com/openbangla/i/ubuntu.conf | sed "s/@NAME@/$UBUNTU_CODENAME/" | sudo tee /etc/apt/sources.list.d/openbangla.list
+sudo sh -c "curl https://dl.bintray.com/openbangla/i/pub.key | apt-key add -"
+sudo sh -c "curl https://dl.bintray.com/openbangla/i/ubuntu.conf | sed s/@NAME@/$UBUNTU_CODENAME/ > /etc/apt/sources.list.d/openbangla.list"
 sudo apt-get update
 ```
 
@@ -88,8 +88,8 @@ sudo apt-get update
 Run these commands to set up our repository:
 ```bash
 source /etc/os-release
-curl https://dl.bintray.com/openbangla/i/pub.key | sudo apt-key add -
-curl https://dl.bintray.com/openbangla/i/debian.conf | sed "s/@NAME@/$VERSION_CODENAME/" | sudo tee /etc/apt/sources.list.d/openbangla.list
+sudo sh -c "curl https://dl.bintray.com/openbangla/i/pub.key | apt-key add -"
+sudo sh -c "curl https://dl.bintray.com/openbangla/i/debian.conf | sed s/@NAME@/$VERSION_CODENAME/ > /etc/apt/sources.list.d/openbangla.list"
 sudo apt-get update
 ```
 
@@ -97,15 +97,15 @@ sudo apt-get update
 Run these commands to set up our repository:
 ```bash
 sudp rpm --import https://dl.bintray.com/openbangla/i/pub.key
-curl https://dl.bintray.com/openbangla/i/fedora.conf | sudo tee /etc/yum.repos.d/openbangla.repo
+sudo sh -c "curl https://dl.bintray.com/openbangla/i/fedora.conf > /etc/yum.repos.d/openbangla.repo"
 ```
 
 === Archlinux
 Run these commands to set up our repository:
 ```bash
-sudo pacman-key -r 0x00F3092A45393EC8
-sudo pacman-key --lsign-key 0x00F3092A45393EC8
-curl https://dl.bintray.com/openbangla/i/archlinux.conf | sudo tee -a /etc/pacman.conf
+sudo sh -c "curl https://dl.bintray.com/openbangla/i/pub.key | pacman-key -a -"
+sudo pacman-key --lsign-key "openbanglateam@gmail.com"
+sudo sh -c "curl https://dl.bintray.com/openbangla/i/archlinux.conf >> /etc/pacman.conf"
 sudo pacman -Syy
 ```
 

--- a/README.adoc
+++ b/README.adoc
@@ -138,20 +138,21 @@ OpenBangla Keyboard currently has the following build dependencies:
 * CMake
 * Qt 5.5 or later
 * iBus development library
+* Zstandard compression library (zstd)
 
 On a Ubuntu/Debian system you can easily install them like this:
 ```bash
-sudo apt-get install build-essential rustc cargo cmake libibus-1.0-dev qt5-default
+sudo apt-get install build-essential rustc cargo cmake libibus-1.0-dev qt5-default libzstd-dev
 ```
 
 On a Fedora system you can easily install them like this:
 ```bash
-sudo dnf install @buildsys-build rust cargo cmake qt5-qtdeclarative-devel ibus-devel
+sudo dnf install @buildsys-build rust cargo cmake qt5-qtdeclarative-devel ibus-devel libzstd-devel
 ```
 
 On a Arch Linux / Arch Based system you can easily install them like this:
 ```bash
-sudo pacman -S base-devel rust cmake qt5-base libibus
+sudo pacman -S base-devel rust cmake qt5-base libibus zstd
 ```
 
 After you have installed required libraries and binaries, clone this repository and change to the cloned folder:

--- a/README.bn.adoc
+++ b/README.bn.adoc
@@ -137,18 +137,19 @@ https://discord.gg/HXK7QnJ[ডিসকর্ড] এবং https://www.facebook
 * CMake
 * Qt 5.5 or later
 * iBus development library
+* Zstandard compression library (zstd)
 
 উবুন্টু/ডেবিয়ান ভিত্তিক সিস্টেমে ডিপেন্ডেসিগুলো ইনস্টলের কমান্ড:
 ```bash
-sudo apt-get install build-essential rustc cargo cmake libibus-1.0-dev qt5-default
+sudo apt-get install build-essential rustc cargo cmake libibus-1.0-dev qt5-default libzstd-dev
 ```
 ফেদোরাতে ডিপেন্ডেসিগুলো ইনস্টলের কমান্ড:
 ```bash
-sudo dnf install @buildsys-build rust cargo cmake qt5-qtdeclarative-devel ibus-devel
+sudo dnf install @buildsys-build rust cargo cmake qt5-qtdeclarative-devel ibus-devel libzstd-devel
 ```
 আর্চলিনাক্স ভিত্তিক সিস্টেমে ডিপেন্ডেসিগুলো ইনস্টলের কমান্ড:
 ```bash
-sudo pacman -S base-devel rust cmake qt5-base libibus
+sudo pacman -S base-devel rust cmake qt5-base libibus zstd
 ```
 
 বিল্ড ডিপেন্ডেন্সিগুলো ইনস্টলের পর ওপেনবাংলা কিবোর্ডের সোর্স কোড রিপজিটরিটি ক্লোন করুন এবং ক্লোন করা ডিরেক্টরিতে প্রবেশ করুন:

--- a/README.bn.adoc
+++ b/README.bn.adoc
@@ -77,8 +77,8 @@ IMPORTANT: ওপেনবাংলা কিবোর্ড ১.৫.১ অথ�
 নিচের কমান্ডগুলো দিয়ে আমাদের রিপজিটরি যোগ করে নিন:
 ```bash
 source /etc/os-release
-curl https://dl.bintray.com/openbangla/i/pub.key | sudo apt-key add -
-curl https://dl.bintray.com/openbangla/i/ubuntu.conf | sed "s/@NAME@/$UBUNTU_CODENAME/" | sudo tee /etc/apt/sources.list.d/openbangla.list
+sudo sh -c "curl https://dl.bintray.com/openbangla/i/pub.key | apt-key add -"
+sudo sh -c "curl https://dl.bintray.com/openbangla/i/ubuntu.conf | sed s/@NAME@/$UBUNTU_CODENAME/ > /etc/apt/sources.list.d/openbangla.list"
 sudo apt-get update
 ```
 
@@ -86,8 +86,8 @@ sudo apt-get update
 নিচের কমান্ডগুলো দিয়ে আমাদের রিপজিটরি যোগ করে নিন:
 ```bash
 source /etc/os-release
-curl https://dl.bintray.com/openbangla/i/pub.key | sudo apt-key add -
-curl https://dl.bintray.com/openbangla/i/debian.conf | sed "s/@NAME@/$VERSION_CODENAME/" | sudo tee /etc/apt/sources.list.d/openbangla.list
+sudo sh -c "curl https://dl.bintray.com/openbangla/i/pub.key | apt-key add -"
+sudo sh -c "curl https://dl.bintray.com/openbangla/i/debian.conf | sed s/@NAME@/$VERSION_CODENAME/ > /etc/apt/sources.list.d/openbangla.list"
 sudo apt-get update
 ```
 
@@ -95,15 +95,15 @@ sudo apt-get update
 নিচের কমান্ডগুলো দিয়ে আমাদের রিপজিটরি যোগ করে নিন:
 ```bash
 sudp rpm --import https://dl.bintray.com/openbangla/i/pub.key
-curl https://dl.bintray.com/openbangla/i/fedora.conf | sudo tee /etc/yum.repos.d/openbangla.repo
+sudo sh -c "curl https://dl.bintray.com/openbangla/i/fedora.conf > /etc/yum.repos.d/openbangla.repo"
 ```
 
 === আর্চলিনাক্স
 নিচের কমান্ডগুলো দিয়ে আমাদের রিপজিটরি যোগ করে নিন:
 ```bash
-sudo pacman-key -r 0x00F3092A45393EC8
-sudo pacman-key --lsign-key 0x00F3092A45393EC8
-curl https://dl.bintray.com/openbangla/i/archlinux.conf | sudo tee -a /etc/pacman.conf
+sudo sh -c "curl https://dl.bintray.com/openbangla/i/pub.key | pacman-key -a -"
+sudo pacman-key --lsign-key "openbanglateam@gmail.com"
+sudo sh -c "curl https://dl.bintray.com/openbangla/i/archlinux.conf >> /etc/pacman.conf"
 sudo pacman -Syy
 ```
 

--- a/README.bn.adoc
+++ b/README.bn.adoc
@@ -67,18 +67,57 @@ toc::[]
   ** চন্দ্রবিন্দুর অবস্থান সংশোধন।
 
 
-== ইনস্টল
+== ইনস্টল  পদ্ধতি
 
-WARNING: ওপেনবাংলা কিবোর্ড ১.২.০ অথবা পূর্ববর্তী সংস্করণ ইনস্টল করা থাকলে সেটি প্রথমে আনইনস্টল করে নিন।
+IMPORTANT: ওপেনবাংলা কিবোর্ড ১.৫.১ অথবা পূর্ববর্তী সংস্করণ ইনস্টল করা থাকলে সেটি প্রথমে আনইনস্টল করে নিন।
 
-ইনস্টলের সময় **কার্যকর ইন্টারনেট সংযোগ** প্রয়োজন।
+প্রথমে আপনার ডিস্ট্রোর জন্য আমাদের রিপজিটরি যোগ করুন, তারপর  আপনার প্যাকেজ ম্যানেজার দিয়ে স্বাভাবিকভাবে ইনস্টল করতে পারবেন।
 
-ওপেনবাংলা কিবোর্ড ইন্সটল করার জন্য টার্মিনাল উইন্ডো খুলে এই কমান্ডটি রান করুন:
+=== উবুন্টু এবং উবুন্টু-ভিত্তিক ডিস্ট্রো
+নিচের কমান্ডগুলো দিয়ে আমাদের রিপজিটরি যোগ করে নিন:
 ```bash
-bash -c "$(wget -nv -O- https://bit.ly/OBK-sh)"
+source /etc/os-release
+curl https://dl.bintray.com/openbangla/i/pub.key | sudo apt-key add -
+curl https://dl.bintray.com/openbangla/i/ubuntu.conf | sed "s/@NAME@/$UBUNTU_CODENAME/" | sudo tee /etc/apt/sources.list.d/openbangla.list
+sudo apt-get update
 ```
 
-এরপর আইবাসের উইন্ডো থেকে অথবা `ibus-setup` কমান্ডের মাধ্যমে **OpenBangla Keyboard** ইনপুট পদ্ধতি হিসেবে যোগ করে নিন।
+=== ডেবিয়ান
+নিচের কমান্ডগুলো দিয়ে আমাদের রিপজিটরি যোগ করে নিন:
+```bash
+source /etc/os-release
+curl https://dl.bintray.com/openbangla/i/pub.key | sudo apt-key add -
+curl https://dl.bintray.com/openbangla/i/debian.conf | sed "s/@NAME@/$VERSION_CODENAME/" | sudo tee /etc/apt/sources.list.d/openbangla.list
+sudo apt-get update
+```
+
+=== ফেদোরা
+নিচের কমান্ডগুলো দিয়ে আমাদের রিপজিটরি যোগ করে নিন:
+```bash
+sudp rpm --import https://dl.bintray.com/openbangla/i/pub.key
+curl https://dl.bintray.com/openbangla/i/fedora.conf | sudo tee /etc/yum.repos.d/openbangla.repo
+```
+
+=== আর্চলিনাক্স
+নিচের কমান্ডগুলো দিয়ে আমাদের রিপজিটরি যোগ করে নিন:
+```bash
+sudo pacman-key -r 0x00F3092A45393EC8
+sudo pacman-key --lsign-key 0x00F3092A45393EC8
+curl https://dl.bintray.com/openbangla/i/archlinux.conf | sudo tee -a /etc/pacman.conf
+sudo pacman -Syy
+```
+
+=== শেষ ধাপ
+ব্যাস! এখন আপনার সিস্টেমের প্যাকেজ ম্যানেজার দিয়ে স্বাভাবিকভাবেই ওপেনবাংলা কিবোর্ড ইনস্টল করতে পারবেন!
+```
+sudo apt-get install openbangla-keyboard
+sudo dnf install openbangla-keyboard
+sudo pacman -S openbangla-keyboard
+```
+
+এছাড়া আমাদের https://github.com/OpenBangla/OpenBangla-Keyboard/releases[রিলিজ] পাতা থেকে উপযুক্ত প্যাকেজ ডাউনলোড করেও ইনস্টল করতে পারেন।
+
+ইন্সটলের পরে আইবাসের উইন্ডো থেকে অথবা `ibus-setup` কমান্ডের মাধ্যমে **OpenBangla Keyboard** ইনপুট পদ্ধতি হিসেবে যোগ করে নিন।
 
 ওপেনবাংলা কিবোর্ড ইনস্টলের পর আপনার https://github.com/OpenBangla/OpenBangla-Keyboard/wiki/Configuring-Environment[ডেস্কটপ এনভায়রনমেন্ট কনফিগার] করার প্রয়োজন হতে পারে।
 
@@ -90,7 +129,7 @@ https://discord.gg/HXK7QnJ[ডিসকর্ড] এবং https://www.facebook
 
 == কম্পাইল
 
-ওপেনবাংলা কিবোর্ড কম্পাইলের তথা সোর্সকোড থেকে বিল্ড করার জন্য বর্তমানে নিম্নোলিখিত ডিপেন্ডেসিগুলো প্রয়োজন:
+ওপেনবাংলা কিবোর্ড কম্পাইল তথা সোর্সকোড থেকে বিল্ড করার জন্য বর্তমানে নিম্নোলিখিত ডিপেন্ডেসিগুলো প্রয়োজন:
 
 * GNU GCC, G++ compiler or Clang
 * Rust 1.34.0 or later


### PR DESCRIPTION
updates readme with install information for PR #130

== tasks ==
- [x] `some_command | sudo some_command` - this form is not very user-friendly.
  the sudo prompt might pop up in the middle of output.
  <span title="on the other hand">otoh</span>, separating the pipes will increase the number of commands, which is also not desirable.
  possible solutions:
  - ❌ `sudo command | sudo command` - run each subcmd with sudo.
  - ✔ `sudo sh -c 'command | command'` - run in sudoed subshell.
  - ❌ `sudo command <<EOF\n command\nEOF` - too complex.
- [x] update dependency list