### PR TITLE
Redesign the Layout viewer dialog

### DIFF
--- a/src/frontend/LayoutViewer.cpp
+++ b/src/frontend/LayoutViewer.cpp
@@ -16,6 +16,7 @@
  *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <QCloseEvent>
 #include <zstd.h>
 #include "LayoutViewer.h"
 #include "Settings.h"
@@ -41,16 +42,26 @@ LayoutViewer::~LayoutViewer() {
 void LayoutViewer::refreshLayoutViewer() {
   image0.clear();
   image1.clear();
+  ui->viewAltGr->setEnabled(false);
+  ui->viewNormal->setEnabled(false);
+  ui->labelImage->setText("");
 
   desc = gLayout->getDesc();
   this->setWindowTitle(desc.name + " :: Layout Viewer");
 
-  image0 = decodeAndDecompress(desc.image0);
-  if(desc.image1.size() != 0) {
-    image1 = decodeAndDecompress(desc.image1);
+  if(desc.image0.size() != 0) {
+    image0 = decodeAndDecompress(desc.image0);
+    if(desc.image1.size() != 0) {
+      image1 = decodeAndDecompress(desc.image1);
+      ui->viewAltGr->setEnabled(true);
+    }
+    ui->viewNormal->setEnabled(true);
+    on_viewNormal_clicked();
+  } else {
+    ui->labelImage->setText("No image to display!");
+    this->resize(537, 152);
   }
 
-  on_viewNormal_clicked();
   // This refreshes Layout Info Dialog
   aboutDialog->setDialogType(AboutLayout);
 }
@@ -60,9 +71,9 @@ void LayoutViewer::showLayoutInfoDialog() {
   aboutDialog->show();
 }
 
-void LayoutViewer::on_buttonClose_clicked() {
+void LayoutViewer::closeEvent(QCloseEvent *event) {
   gSettings->setLayoutViewerWindowPosition(this->pos());
-  LayoutViewer::close();
+  event->accept();
 }
 
 void LayoutViewer::on_buttonAboutLayout_clicked() {
@@ -70,26 +81,25 @@ void LayoutViewer::on_buttonAboutLayout_clicked() {
 }
 
 void LayoutViewer::on_viewNormal_clicked() {
-  ui->labelImage->setText("");
   image.loadFromData(image0);
   ui->labelImage->setPixmap(QPixmap::fromImage(image));
   ui->labelImage->adjustSize();
-  this->setFixedHeight(ui->labelImage->height() + ui->labelImage->y());
-  this->setFixedWidth(ui->labelImage->width());
+  QSize size;
+  size.setHeight(ui->labelImage->height() + ui->labelImage->y());
+  size.setWidth(ui->labelImage->width());
+  this->resize(size);
   ui->viewNormal->setChecked(true);
 }
 
 void LayoutViewer::on_viewAltGr_clicked() {
-  if (image1.size() != 0) {
-    image.loadFromData(image1);
-    ui->labelImage->setPixmap(QPixmap::fromImage(image));
-    ui->labelImage->adjustSize();
-    this->setFixedHeight(ui->labelImage->height() + ui->labelImage->y());
-    this->setFixedWidth(ui->labelImage->width());
-    ui->viewAltGr->setChecked(true);
-  } else {
-    ui->labelImage->setText("No image to display!");
-  }
+  image.loadFromData(image1);
+  ui->labelImage->setPixmap(QPixmap::fromImage(image));
+  ui->labelImage->adjustSize();
+  QSize size;
+  size.setHeight(ui->labelImage->height() + ui->labelImage->y());
+  size.setWidth(ui->labelImage->width());
+  this->resize(size);
+  ui->viewAltGr->setChecked(true);
 }
 
 QByteArray LayoutViewer::decodeAndDecompress(QByteArray &data) {

--- a/src/frontend/LayoutViewer.h
+++ b/src/frontend/LayoutViewer.h
@@ -42,9 +42,10 @@ public:
 
   void showLayoutInfoDialog();
 
-private slots:
+protected:
+  void closeEvent(QCloseEvent *event) override;
 
-  void on_buttonClose_clicked();
+private slots:
 
   void on_buttonAboutLayout_clicked();
 

--- a/src/frontend/LayoutViewer.ui
+++ b/src/frontend/LayoutViewer.ui
@@ -6,83 +6,132 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>779</width>
-    <height>417</height>
+    <width>914</width>
+    <height>192</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Dialog</string>
   </property>
-  <layout class="QGridLayout" name="gridLayout">
-   <property name="horizontalSpacing">
-    <number>13</number>
-   </property>
-   <property name="verticalSpacing">
-    <number>6</number>
-   </property>
-   <item row="0" column="3">
-    <widget class="QPushButton" name="buttonZoomOut">
-     <property name="enabled">
-      <bool>false</bool>
-     </property>
-     <property name="text">
-      <string/>
-     </property>
-     <property name="icon">
-      <iconset resource="images.qrc">
-       <normaloff>:/images/zoom-out.png</normaloff>:/images/zoom-out.png</iconset>
-     </property>
-    </widget>
+  <property name="sizeGripEnabled">
+   <bool>true</bool>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <spacer name="horizontalSpacer">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QPushButton" name="viewNormal">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="text">
+        <string>Normal View</string>
+       </property>
+       <property name="icon">
+        <iconset resource="images.qrc">
+         <normaloff>:/images/keyboard_layout.png</normaloff>:/images/keyboard_layout.png</iconset>
+       </property>
+       <property name="checkable">
+        <bool>true</bool>
+       </property>
+       <property name="checked">
+        <bool>true</bool>
+       </property>
+       <property name="autoExclusive">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="viewAltGr">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="text">
+        <string>AltGr View</string>
+       </property>
+       <property name="icon">
+        <iconset resource="images.qrc">
+         <normaloff>:/images/keyboard_layout.png</normaloff>:/images/keyboard_layout.png</iconset>
+       </property>
+       <property name="checkable">
+        <bool>true</bool>
+       </property>
+       <property name="checked">
+        <bool>false</bool>
+       </property>
+       <property name="autoExclusive">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer_2">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QPushButton" name="buttonAboutLayout">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="toolTip">
+        <string>About this Layout</string>
+       </property>
+       <property name="text">
+        <string/>
+       </property>
+       <property name="icon">
+        <iconset resource="images.qrc">
+         <normaloff>:/images/about.png</normaloff>:/images/about.png</iconset>
+       </property>
+      </widget>
+     </item>
+    </layout>
    </item>
-   <item row="0" column="1">
-    <widget class="QPushButton" name="viewAltGr">
-     <property name="text">
-      <string>AltGr View</string>
-     </property>
-     <property name="icon">
-      <iconset resource="images.qrc">
-       <normaloff>:/images/keyboard_layout.png</normaloff>:/images/keyboard_layout.png</iconset>
-     </property>
-     <property name="checkable">
-      <bool>true</bool>
-     </property>
-     <property name="checked">
-      <bool>false</bool>
-     </property>
-     <property name="autoExclusive">
-      <bool>true</bool>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="5">
-    <widget class="QPushButton" name="buttonAboutLayout">
-     <property name="text">
-      <string>About Layout</string>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="6">
-    <widget class="QPushButton" name="buttonClose">
-     <property name="text">
-      <string>Close</string>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="2">
-    <widget class="QPushButton" name="buttomZoomIn">
-     <property name="enabled">
-      <bool>false</bool>
-     </property>
-     <property name="text">
-      <string/>
-     </property>
-     <property name="icon">
-      <iconset resource="images.qrc">
-       <normaloff>:/images/zoom-in.png</normaloff>:/images/zoom-in.png</iconset>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="0" colspan="7">
+   <item>
     <widget class="QLabel" name="labelImage">
      <property name="frameShape">
       <enum>QFrame::StyledPanel</enum>
@@ -94,39 +143,6 @@
       <bool>true</bool>
      </property>
     </widget>
-   </item>
-   <item row="0" column="0">
-    <widget class="QPushButton" name="viewNormal">
-     <property name="text">
-      <string>Normal View</string>
-     </property>
-     <property name="icon">
-      <iconset resource="images.qrc">
-       <normaloff>:/images/keyboard_layout.png</normaloff>:/images/keyboard_layout.png</iconset>
-     </property>
-     <property name="checkable">
-      <bool>true</bool>
-     </property>
-     <property name="checked">
-      <bool>true</bool>
-     </property>
-     <property name="autoExclusive">
-      <bool>true</bool>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="4">
-    <spacer name="horizontalSpacer">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>40</width>
-       <height>20</height>
-      </size>
-     </property>
-    </spacer>
    </item>
   </layout>
  </widget>


### PR DESCRIPTION
* Layout viewer is now resizable.
* Window contents dynamically resize along with the dialog.
* Removed the unimplemented Zooming buttons.
* View buttons dynamically enable itself with respect to the selected dialog.
* About Layout is now simply a button with an icon.
* Layout Viewer now handles layout without an image gracefully.

![NewLayoutAvro](https://user-images.githubusercontent.com/9459891/80869914-e6178080-8cc4-11ea-8a14-63063968873d.png)
![NewLayoutJatiya](https://user-images.githubusercontent.com/9459891/80869919-e9ab0780-8cc4-11ea-9478-8cc72e227a20.png)

Closes #115 