### PR TITLE
Don't bypass the window manager

### DIFF
--- a/src/frontend/TopBar.cpp
+++ b/src/frontend/TopBar.cpp
@@ -76,13 +76,7 @@ TopBar::~TopBar() {
 }
 
 void TopBar::SetupTopBar() {
-#if defined(linux) || defined(__linux__) || defined(__linux)
-  this->setWindowFlags(
-      Qt::Window | Qt::FramelessWindowHint | Qt::WindowStaysOnTopHint | Qt::X11BypassWindowManagerHint |
-          Qt::WindowDoesNotAcceptFocus | Qt::NoDropShadowWindowHint);
-#else
   this->setWindowFlags(Qt::Window | Qt::FramelessWindowHint | Qt::WindowStaysOnTopHint);
-#endif
   this->setFixedSize(QSize(this->width(), this->height()));
 
   if (gSettings->getTopBarWindowPosition() == QPoint(0, 0)) {

--- a/src/frontend/TopBar.ui
+++ b/src/frontend/TopBar.ui
@@ -72,7 +72,7 @@
      </rect>
     </property>
     <property name="toolTip">
-     <string>View information about current layout</string>
+     <string>View information about the current layout</string>
     </property>
     <property name="icon">
      <iconset resource="images.qrc">
@@ -116,6 +116,9 @@
       <width>27</width>
       <height>27</height>
      </rect>
+    </property>
+    <property name="toolTip">
+     <string>Quit</string>
     </property>
     <property name="text">
      <string/>


### PR DESCRIPTION
* Removed `Qt::X11BypassWindowManagerHint` to prevent nasty bugs like #153 where the window manager loses the track of the TopBar.
* Removed `Qt::WindowDoesNotAcceptFocus` to get tooltips on the TopBar buttons.
* Removed `Qt::NoDropShadowWindowHint` as this doesn't prevent drop shadow of Topbar anyway and I don't think having shadow around the TopBar when it has focus is a bad choice.
* Tooltip updates.

cc @ahmubashshir 