### PR TITLE
Update DEPLOY workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,7 +8,7 @@ on:
 jobs:
 
   build:
-    if: contains(github.event.head_commit.message, 'deploy+')
+    if: contains(github.event.head_commit.message, 'deploy+') || contains(github.event.head_commit.message, 'pkg+')
     strategy:
       matrix:
         container: [ "ubuntu:18.04", "ubuntu:19.10", "ubuntu:20.04", "debian:9", "debian:10", "fedora:29", "fedora:30", "fedora:31", "fedora:32", "archlinux:latest" ]
@@ -37,6 +37,7 @@ jobs:
           path: artifact
 
   deploy:
+    if: contains(github.event.head_commit.message, 'deploy+')
     needs: build
     runs-on: "ubuntu-latest"
     container:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,7 +11,7 @@ jobs:
     if: contains(github.event.head_commit.message, 'deploy+') || contains(github.event.head_commit.message, 'pkg+')
     strategy:
       matrix:
-        container: [ "ubuntu:18.04", "ubuntu:19.10", "ubuntu:20.04", "debian:9", "debian:10", "fedora:29", "fedora:30", "fedora:31", "fedora:32", "archlinux:latest" ]
+        container: [ "ubuntu:18.04", "ubuntu:19.10", "ubuntu:20.04", "debian:9", "debian:10", "fedora:29", "fedora:30", "fedora:31", "fedora:32", "fedora:33", "archlinux:latest" ]
         # this list should be updated from time to time by consulting these pages:
         # https://releases.ubuntu.com/
         # https://wiki.debian.org/DebianReleases#Production_Releases

--- a/src/frontend/LayoutViewer.cpp
+++ b/src/frontend/LayoutViewer.cpp
@@ -104,7 +104,8 @@ void LayoutViewer::on_viewAltGr_clicked() {
 
 QByteArray LayoutViewer::decodeAndDecompress(QByteArray &data) {
   std::string decoded = base91::decode(std::string(data.data(), data.size()));
-  unsigned long long cap = ZSTD_getFrameContentSize(decoded.data(), decoded.size());
+  // Use ZSTD_getFrameContentSize() function when we can hard depend on zstd 1.3.0
+  unsigned long long cap = ZSTD_getDecompressedSize(decoded.data(), decoded.size());
   char *imgData = (char *)malloc(cap);
 
   size_t decompressed = ZSTD_decompress(imgData, cap, decoded.data(), decoded.size());

--- a/tools/README.md
+++ b/tools/README.md
@@ -3,5 +3,6 @@
 Builds OpenBangla Keyboard packages for various distributions.
 
 - A lightweight C/I workflow runs by default on each commit.
-- if commit message has the string `deploy+`, then a deploy workflow runs instead of the default one.
-  - if build passes, this workflow will deploy packages to repositories, and create a github release.
+- if commit message has the string `pkg+` or `deploy+`, then a deploy workflow runs instead of the default one.
+  - if build passes & `pkg+` is present, this workflow will upload the packages as Github Actions artifacts.
+  - if build passes & `deploy+` is present, this workflow will deploy packages to repositories, and create a github release.

--- a/tools/build.sh
+++ b/tools/build.sh
@@ -5,7 +5,8 @@ RELEASE_STUB="OpenBangla-Keyboard_${RELEASE_VERSION}-"
 
 makeDeb () {
     RELEASE_FILENAME="${RELEASE_STUB}${DIST}.deb"
-    apt-get -y install build-essential cmake libibus-1.0-dev libzstd-dev qt5-default rustc cargo ninja-build curl
+    apt-get -y install build-essential cmake libibus-1.0-dev libzstd-dev qt5-default ninja-build curl
+    curl https://sh.rustup.rs -sSf | sh -s -- --profile minimal --default-toolchain stable
     cmake -H"$GITHUB_WORKSPACE" -B/build -GNinja -DCPACK_GENERATOR=DEB
     ninja package -C /build
     RELEASE_FILE="/build/${RELEASE_FILENAME}"
@@ -13,7 +14,8 @@ makeDeb () {
 
 makeRpm () {
     RELEASE_FILENAME="${RELEASE_STUB}${DIST}.rpm"
-    dnf install -y --allowerasing @buildsys-build cmake ibus-devel libzstd-devel qt5-qtdeclarative-devel rust cargo ninja-build
+    dnf install -y --allowerasing @buildsys-build cmake ibus-devel libzstd-devel qt5-qtdeclarative-devel ninja-build curl
+    curl https://sh.rustup.rs -sSf | sh -s -- --profile minimal --default-toolchain stable
     cmake -H"$GITHUB_WORKSPACE" -B/build -GNinja -DCPACK_GENERATOR=RPM
     ninja package -C /build
     RELEASE_FILE="/build/${RELEASE_FILENAME}"

--- a/tools/build.sh
+++ b/tools/build.sh
@@ -6,7 +6,7 @@ RELEASE_STUB="OpenBangla-Keyboard_${RELEASE_VERSION}-"
 makeDeb () {
     RELEASE_FILENAME="${RELEASE_STUB}${DIST}.deb"
     apt-get -y install build-essential cmake libibus-1.0-dev libzstd-dev qt5-default ninja-build curl
-    curl https://sh.rustup.rs -sSf | sh -s -- --profile minimal --default-toolchain stable
+    curl https://sh.rustup.rs -sSf | sh -s -- -y --profile minimal --default-toolchain stable
     cmake -H"$GITHUB_WORKSPACE" -B/build -GNinja -DCPACK_GENERATOR=DEB
     ninja package -C /build
     RELEASE_FILE="/build/${RELEASE_FILENAME}"
@@ -15,7 +15,7 @@ makeDeb () {
 makeRpm () {
     RELEASE_FILENAME="${RELEASE_STUB}${DIST}.rpm"
     dnf install -y --allowerasing @buildsys-build cmake ibus-devel libzstd-devel qt5-qtdeclarative-devel ninja-build curl
-    curl https://sh.rustup.rs -sSf | sh -s -- --profile minimal --default-toolchain stable
+    curl https://sh.rustup.rs -sSf | sh -s -- -y --profile minimal --default-toolchain stable
     cmake -H"$GITHUB_WORKSPACE" -B/build -GNinja -DCPACK_GENERATOR=RPM
     ninja package -C /build
     RELEASE_FILE="/build/${RELEASE_FILENAME}"

--- a/tools/build.sh
+++ b/tools/build.sh
@@ -27,9 +27,7 @@ makeArch () {
     PKGEXT=".pkg.tar.zst"
     echo "PKGEXT='$PKGEXT'" >> /etc/makepkg.conf
     RELEASE_FILENAME="${RELEASE_STUB}${DIST}${PKGEXT}"
-    pacman -S --noconfirm --needed base-devel cmake libibus zstd qt5-base curl
-    curl https://sh.rustup.rs -sSf | sh -s -- -y --profile minimal --default-toolchain stable
-    source $HOME/.cargo/env
+    pacman -S --noconfirm --needed base-devel cmake libibus zstd qt5-base rust curl
     mkdir /build
     cd /build
     cp -fpr "$GITHUB_WORKSPACE" /build/src

--- a/tools/build.sh
+++ b/tools/build.sh
@@ -27,7 +27,8 @@ makeArch () {
     PKGEXT=".pkg.tar.zst"
     echo "PKGEXT='$PKGEXT'" >> /etc/makepkg.conf
     RELEASE_FILENAME="${RELEASE_STUB}${DIST}${PKGEXT}"
-    pacman -S --noconfirm --needed base-devel cmake libibus zstd qt5-base rust curl
+    pacman -S --noconfirm --needed base-devel cmake libibus zstd qt5-base curl
+    curl https://sh.rustup.rs -sSf | sh -s -- -y --profile minimal --default-toolchain stable
     mkdir /build
     cd /build
     cp -fpr "$GITHUB_WORKSPACE" /build/src

--- a/tools/build.sh
+++ b/tools/build.sh
@@ -29,6 +29,7 @@ makeArch () {
     RELEASE_FILENAME="${RELEASE_STUB}${DIST}${PKGEXT}"
     pacman -S --noconfirm --needed base-devel cmake libibus zstd qt5-base curl
     curl https://sh.rustup.rs -sSf | sh -s -- -y --profile minimal --default-toolchain stable
+    source $HOME/.cargo/env
     mkdir /build
     cd /build
     cp -fpr "$GITHUB_WORKSPACE" /build/src


### PR DESCRIPTION
* Adds a leeway `pkg+` to build packages only and upload them as GHA artifacts.
* Backwards compatibility with zstd >= 1.1.2 to fix the build failure in Debian 9. (Previously we depended on zstd >= 1.3.0)
* Use **rustup** to install the latest Rust stable version available in Ubuntu, Debian and Fedora distributions.

[Here's the successful build with `pkg+` and all of these changes.](https://github.com/OpenBangla/OpenBangla-Keyboard/actions/runs/273794360)
