### PR TITLE
Maintain Filesystem Hierarchy Standard while installing binary executable files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,6 +49,7 @@ if (OS_LINUX)
 
     ## Set Directories for installing and storing files
     set(CMAKE_INSTALL_PREFIX "/usr")
+    set(BIN_DIR "${CMAKE_INSTALL_PREFIX}/bin")
     set(DATADIR "${CMAKE_INSTALL_PREFIX}/share")
     set(PROJECT_DATADIR "${DATADIR}/openbangla-keyboard")
     add_definitions(-DPROJECT_DATADIR="${PROJECT_DATADIR}")

--- a/data/openbangla-keyboard.desktop.in
+++ b/data/openbangla-keyboard.desktop.in
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Name=OpenBangla Keyboard
 Comment=An OpenSource, Unicode compliant Bengali Input Method.
-Exec=@PROJECT_DATADIR@/openbangla-gui %f
+Exec=@BIN_DIR@/openbangla-gui %f
 Icon=openbangla-keyboard
 Type=Application
 Categories=Utility;Application;

--- a/data/openbangla.xml.in
+++ b/data/openbangla.xml.in
@@ -4,7 +4,7 @@
 <component>
     <name>org.freedesktop.IBus.OpenBangla</name>
     <description>OpenBangla Keyboard</description>
-    <exec>@PROJECT_DATADIR@/ibus-openbangla --ibus</exec>
+    <exec>@BIN_DIR@/ibus-openbangla --ibus</exec>
     <version>@PROJECT_VERSION@</version>
     <author>See About Dialog</author>
     <license>GPL 3</license>

--- a/src/engine/ibus/CMakeLists.txt
+++ b/src/engine/ibus/CMakeLists.txt
@@ -79,4 +79,4 @@ install(FILES ${CMAKE_SOURCE_DIR}/data/io.github.openbangla.keyboard.metainfo.xm
         DESTINATION ${DATADIR}/metainfo)
 
 install(TARGETS ibus-openbangla
-        RUNTIME DESTINATION ${PROJECT_DATADIR})
+        RUNTIME DESTINATION ${BIN_DIR})

--- a/src/frontend/CMakeLists.txt
+++ b/src/frontend/CMakeLists.txt
@@ -25,4 +25,4 @@ add_executable(openbangla-gui ${SRC_MAIN} ${SRC_GUI})
 target_link_libraries(openbangla-gui libShared 3rdParty Qt5::Widgets Qt5::Network ${ZSTD_LIBRARIES})
 
 install(TARGETS openbangla-gui
-        RUNTIME DESTINATION ${PROJECT_DATADIR})
+        RUNTIME DESTINATION ${BIN_DIR})


### PR DESCRIPTION
This resolves the issue raised in #183 
Now the executable files are installed in:
```
/usr/bin/ibus-openbangla
/usr/bin/openbangla-gui
```
@natrys can you check it, please?