### PR TITLE
Controlling the inclusion of 3rdParty code(QSimpleUpdater)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,29 +19,33 @@ find_package(Qt5Widgets REQUIRED)
 find_package(Qt5Network REQUIRED)
 
 # Get system information. WIN32 and APPLE are defined by CMake
-if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
     set(OS_LINUX 1)
-endif (CMAKE_SYSTEM_NAME STREQUAL "Linux")
+endif()
 
 # Set build type to "Release" if user did not specify any build type yet
 # Other possible values: Debug, Release, RelWithDebInfo and MinSizeRel
-if (NOT CMAKE_BUILD_TYPE)
+if(NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE Release)
-endif (NOT CMAKE_BUILD_TYPE)
+endif()
 
-if (CMAKE_BUILD_TYPE STREQUAL "Debug")
+if(CMAKE_BUILD_TYPE STREQUAL "Debug")
     add_definitions(-DDEBUG)
-endif (CMAKE_BUILD_TYPE STREQUAL "Debug")
+endif()
 
 # Sanity check our source directory to make sure that we are not trying to
 # generate an in-tree build (it pollutes the source tree with a lot of CMake
 # related files).
-if (CMAKE_SOURCE_DIR STREQUAL CMAKE_BINARY_DIR)
+if(CMAKE_SOURCE_DIR STREQUAL CMAKE_BINARY_DIR)
     message(FATAL_ERROR "In-source builds are not allowed.\nPlease create a build directory and initiate cmake from there.")
-endif ()
+endif()
+
+if(NO_UPDATE_CHECK) 
+    add_definitions(-DNO_UPDATE_CHECK)
+endif()
 
 # For Linux.
-if (OS_LINUX)
+if(OS_LINUX)
     ## Additions for Linux ##
 
     # Generate compile_commands.json to satisfy vscode linux configuration
@@ -62,14 +66,14 @@ if (OS_LINUX)
     pkg_check_modules(IBUS REQUIRED ibus-1.0)
     ## Find zstd ##
     pkg_check_modules(ZSTD REQUIRED libzstd)
-endif (OS_LINUX)
+endif()
 
 add_subdirectory(src/engine)
 add_subdirectory(src/frontend)
 add_subdirectory(src/shared)
 
 # uninstall target
-if (NOT TARGET uninstall)
+if(NOT TARGET uninstall)
     configure_file(
             "${CMAKE_MODULE_PATH}/cmake_uninstall.cmake.in"
             "${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake"
@@ -77,7 +81,7 @@ if (NOT TARGET uninstall)
 
     add_custom_target(uninstall
             COMMAND ${CMAKE_COMMAND} -P ${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake)
-endif ()
+endif()
 
 
 set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "OpenSource Bengali input method")

--- a/src/frontend/CMakeLists.txt
+++ b/src/frontend/CMakeLists.txt
@@ -4,8 +4,6 @@ set(CMAKE_AUTOUIC ON)
 set(CMAKE_AUTORCC ON)
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
-add_subdirectory(3rdParty)
-
 set(SRC_GUI TopBar.cpp
         AboutDialog.cpp
         AboutFile.cpp
@@ -21,8 +19,15 @@ set(SRC_MAIN main.cpp
         SingleInstance.cpp
         AvroPhonetic.cpp)
 
+set(LINK_LIBS libShared Qt5::Widgets Qt5::Network ${ZSTD_LIBRARIES})
+
+if(NOT NO_UPDATE_CHECK)
+    add_subdirectory(3rdParty)
+    list(APPEND LINK_LIBS 3rdParty)
+endif()
+
 add_executable(openbangla-gui ${SRC_MAIN} ${SRC_GUI})
-target_link_libraries(openbangla-gui libShared 3rdParty Qt5::Widgets Qt5::Network ${ZSTD_LIBRARIES})
+target_link_libraries(openbangla-gui ${LINK_LIBS})
 
 install(TARGETS openbangla-gui
         RUNTIME DESTINATION ${LIBEXECDIR}/openbangla-keyboard)

--- a/src/frontend/SettingsDialog.cpp
+++ b/src/frontend/SettingsDialog.cpp
@@ -30,6 +30,11 @@ SettingsDialog::SettingsDialog(QWidget *parent) :
 
   ui->cmbOrientation->insertItems(0, {"Horizontal", "Vertical"});
 
+#ifdef NO_UPDATE_CHECK
+  ui->lblUpdateCheck->hide();
+  ui->btnCheckUpdate->hide();
+#endif
+
   implementSignals();
   updateSettings();
 }

--- a/src/frontend/SettingsDialog.ui
+++ b/src/frontend/SettingsDialog.ui
@@ -92,7 +92,7 @@
            </widget>
           </item>
           <item row="2" column="0">
-           <widget class="QLabel" name="label_4">
+           <widget class="QLabel" name="lblUpdateCheck">
             <property name="sizePolicy">
              <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
               <horstretch>0</horstretch>

--- a/src/frontend/TopBar.cpp
+++ b/src/frontend/TopBar.cpp
@@ -44,7 +44,6 @@ TopBar::TopBar(QWidget *parent) :
 
   gLayout = new Layout();
   gSettings = new Settings();
-  updater = QSimpleUpdater::getInstance();
 
   /* Dialogs */
   aboutDialog = new AboutDialog(Q_NULLPTR);
@@ -58,9 +57,13 @@ TopBar::TopBar(QWidget *parent) :
   SetupTrayIcon();
   DataMigration();
 
+#ifndef NO_UPDATE_CHECK
+  updater = QSimpleUpdater::getInstance();
+
   if (gSettings->getUpdateCheck()) {
     checkForUpdate();
   }
+#endif
 }
 
 TopBar::~TopBar() {
@@ -94,10 +97,12 @@ void TopBar::SetupTopBar() {
 }
 
 void TopBar::checkForUpdate() {
+#ifndef NO_UPDATE_CHECK
   updater->setModuleVersion(DEFS_URL, PROJECT_VERSION);
   updater->setNotifyOnUpdate(DEFS_URL, true);
   updater->setDownloaderEnabled(DEFS_URL, false);
   updater->checkForUpdates(DEFS_URL);
+#endif
 }
 
 void TopBar::SetupPopupMenus() {
@@ -142,7 +147,9 @@ void TopBar::SetupPopupMenus() {
   iconMenu->addAction(iconMenuHide);
   iconMenu->addAction(iconMenuLayout);
   iconMenu->addAction(iconMenuAbout);
-  iconMenu->addAction(iconMenuUpdate);  
+#ifndef NO_UPDATE_CHECK
+  iconMenu->addAction(iconMenuUpdate);
+#endif
 }
 
 void TopBar::SetupTrayIcon() {

--- a/src/frontend/TopBar.cpp
+++ b/src/frontend/TopBar.cpp
@@ -32,8 +32,10 @@
 #include "SettingsDialog.h"
 #include "LayoutConverter.h"
 #include "AutoCorrectDialog.h"
-#include "QSimpleUpdater.h"
 #include "ui_TopBar.h"
+#ifndef NO_UPDATE_CHECK
+# include "QSimpleUpdater.h"
+#endif
 
 static const QString DEFS_URL = "https://raw.githubusercontent.com/OpenBangla/OpenBangla-Keyboard/master/UPDATES.json";
 

--- a/src/frontend/TopBar.h
+++ b/src/frontend/TopBar.h
@@ -84,7 +84,10 @@ private:
   bool positionChanged = false;
   int pressedMouseX, pressedMouseY;
   QSystemTrayIcon *tray;
+
+#ifndef NO_UPDATE_CHECK
   QSimpleUpdater *updater;
+#endif
 
   /* Dialogs */
   AboutDialog *aboutDialog;


### PR DESCRIPTION
This PR introduces a CMake variable `NO_UPDATE_CHECK` to control the inclusion and linking of the `QSimpleUpdater` project code which is licensed under the [`DBAD`](https://dbad-license.org/) license and does not comply with the Debian Free Software Guidelines (DFSG).
This variable can be enabled by passing CMake the `-D NO_UPDATE_CHECK=1` flag to not include the above update checking code.

cc @gunnarhj