### PR TITLE
`install.sh` again :pensive:

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,7 +11,7 @@ jobs:
     if: contains(github.event.head_commit.message, 'deploy+') || contains(github.event.head_commit.message, 'pkg+')
     strategy:
       matrix:
-        container: [ "ubuntu:18.04", "ubuntu:19.10", "ubuntu:20.04", "debian:9", "debian:10", "fedora:29", "fedora:30", "fedora:31", "fedora:32", "fedora:33", "archlinux:latest" ]
+        container: [ "ubuntu:18.04", "ubuntu:20.04", "ubuntu:21.04", "debian:9", "debian:10", "fedora:32", "fedora:33", "fedora:34", "archlinux:latest" ]
         # this list should be updated from time to time by consulting these pages:
         # https://releases.ubuntu.com/
         # https://wiki.debian.org/DebianReleases#Production_Releases

--- a/README.adoc
+++ b/README.adoc
@@ -74,44 +74,36 @@ toc::[]
 
 IMPORTANT: If you had installed OpenBangla Keyboard 1.5.1 or earlier version, https://github.com/OpenBangla/OpenBangla-Keyboard/wiki/Uninstalling-OpenBangla-Keyboard[please uninstall it first.]
 
-First set up our repositories for your distro, then you can install normally with your package manager.
-
-=== Ubuntu & derivatives
-Run these commands to set up our repository:
+Open your terminal and run this command on your bash shell. NB : It has to be **BASH**, otherwise it won't work.
 ```bash
-source /etc/os-release
-sudo sh -c "wget https://dl.bintray.com/openbangla/i/pub.key -q -O - | apt-key add -"
-sudo sh -c "wget https://dl.bintray.com/openbangla/i/ubuntu.conf -q -O - | sed s/@NAME@/$UBUNTU_CODENAME/ > /etc/apt/sources.list.d/openbangla.list"
-sudo apt update
-sudo apt install openbangla-keyboard
+bash -c "$(wget -q https://raw.githubusercontent.com/OpenBangla/OpenBangla-Keyboard/master/tools/install.sh -O -)"
 ```
 
-=== Debian & derivatives
-Run these commands to set up our repository:
-```bash
-source /etc/os-release
-sudo sh -c "wget https://dl.bintray.com/openbangla/i/pub.key -q -O - | apt-key add -"
-sudo sh -c "wget https://dl.bintray.com/openbangla/i/debian.conf  -q -O - | sed s/@NAME@/$VERSION_CODENAME/ > /etc/apt/sources.list.d/openbangla.list"
-sudo apt update
-sudo apt install openbangla-keyboard
-```
+If this does not workout for you please create an https://github.com/OpenBangla/OpenBangla-Keyboard/issues[Issue]. While we look into the problem you can check the https://github.com/OpenBangla/OpenBangla-Keyboard/wiki/Installing-OpenBangla-Keyboard[Wiki] for Distrowise/Distro-specific Install Instructions.
 
-=== Fedora
-Run these commands to set up our repository:
-```bash
-sudo rpm --import https://dl.bintray.com/openbangla/i/pub.key
-sudo sh -c "curl https://dl.bintray.com/openbangla/i/fedora.conf > /etc/yum.repos.d/openbangla.repo"
-sudo dnf install openbangla-keyboard
-```
+=== Archlinux and it's derivatives
+There are two packages for OpenBangla Keyboard in the Arch User Repository(AUR). Use `openbangla-keyboard` if you want to make and install the package from source. Otherwise, use `openbangla-keyboard-bin` to use the binary package released for Arch and its derivatives by the maintainer. You can install it in one command with your favorite aur helper. Example commands for some popular tools:
 
-=== Archlinux
-Run these commands to set up our repository:
+==== `openbangla-keyboard`
+* `$ pacaur -S openbangla-keyboard`
+* `$ yay -S openbangla-keyboard`
+* `$ yaourt -S openbangla-keyboard`
+
+==== `openbangla-keyboard-bin`
+* `$ pacaur -S openbangla-keyboard-bin`
+* `$ yay -S openbangla-keyboard-bin`
+* `$ yaourt -S openbangla-keyboard-bin`
+
+Or install manually:
 ```bash
-sudo sh -c "curl https://dl.bintray.com/openbangla/i/pub.key | pacman-key -a -"
-sudo pacman-key --lsign-key "openbanglateam@gmail.com"
-sudo sh -c "curl https://dl.bintray.com/openbangla/i/archlinux.conf >> /etc/pacman.conf"
-sudo pacman -Syy
-sudo pacman -S openbangla-keyboard
+sudo pacman -S base-devel git
+git clone https://aur.archlinux.org/openbangla-keyboard.git
+cd openbangla-keyboard
+makepkg -risc
+```
+We also provide a `.pkg.tar.xz` package for Arch Linux which you can easily install by following any of the above instruction for `openbangla-keyboard-bin`. If you want to install it manually, download the installation package from https://github.com/OpenBangla/OpenBangla-Keyboard/releases[releases page] and install OpenBangla Keyboard on your system by running the following command:
+```bash
+$ sudo pacman -U package.pkg.tar.xz
 ```
 
 === Others

--- a/README.adoc
+++ b/README.adoc
@@ -37,11 +37,6 @@ So Avro Keyboard users will feel right at home in Linux with OpenBangla Keyboard
 
 image:https://github.com/OpenBangla/OpenBangla-Keyboard/workflows/CI/badge.svg[CI, link=https://github.com/OpenBangla/OpenBangla-Keyboard/actions?query=workflow%3ACI+branch%3Amaster] {nbsp}
 image:https://img.shields.io/github/downloads/OpenBangla/OpenBangla-Keyboard/total.svg?label=GitHub%20Downloads[Github Downloads, link=https://img.shields.io/github/downloads/OpenBangla/OpenBangla-Keyboard/total.svg?label=GitHub%20Downloads] {nbsp}
-image:https://img.shields.io/bintray/dt/openbangla/ubuntu/openbangla-keyboard?label=Bintray%20Ubuntu[Bintray Ubuntu repo downloads, link=https://img.shields.io/bintray/dt/openbangla/ubuntu/openbangla-keyboard?label=Bintray%20Ubuntu] {nbsp}
-image:https://img.shields.io/bintray/dt/openbangla/debian/openbangla-keyboard?label=Bintray%20Debian[Bintray Debian downloads, link=https://img.shields.io/bintray/dt/openbangla/debian/openbangla-keyboard?label=Bintray%20Debian] {nbsp}
-image:https://img.shields.io/bintray/dt/openbangla/fedora/openbangla-keyboard?label=Bintray%20Fedora[Bintray Fedora downloads, link=https://img.shields.io/bintray/dt/openbangla/fedora/openbangla-keyboard?label=Bintray%20Fedora] {nbsp}
-image:https://img.shields.io/bintray/dt/openbangla/archlinux/openbangla-keyboard?label=Bintray%20Arch%20Linux[Bintray Arch Linux downloads, link=https://img.shields.io/bintray/dt/openbangla/archlinux/openbangla-keyboard?label=Bintray%20Arch%20Linux] {nbsp}
-image:https://img.shields.io/discord/436879388362014740.svg[Discord, link=https://discord.gg/HXK7QnJ]
 
 CAUTION: This project is powered by github 🌟s. Go ahead and *star* it please!
 
@@ -101,9 +96,9 @@ git clone https://aur.archlinux.org/openbangla-keyboard.git
 cd openbangla-keyboard
 makepkg -risc
 ```
-We also provide a `.pkg.tar.xz` package for Arch Linux which you can easily install by following any of the above instruction for `openbangla-keyboard-bin`. If you want to install it manually, download the installation package from https://github.com/OpenBangla/OpenBangla-Keyboard/releases[releases page] and install OpenBangla Keyboard on your system by running the following command:
+We also provide a `.pkg.tar.zst` package for Arch Linux which you can download the installation package from https://github.com/OpenBangla/OpenBangla-Keyboard/releases[releases page] and install OpenBangla Keyboard on your system by running the following command:
 ```bash
-$ sudo pacman -U package.pkg.tar.xz
+$ sudo pacman -U package.pkg.tar.zst
 ```
 
 === Others

--- a/README.bn.adoc
+++ b/README.bn.adoc
@@ -36,11 +36,6 @@ https://www.omicronlab.com/avro-keyboard.html[অভ্র কীবোর্ড
 
 image:https://github.com/OpenBangla/OpenBangla-Keyboard/workflows/CI/badge.svg[CI, link=https://github.com/OpenBangla/OpenBangla-Keyboard/actions?query=workflow%3ACI+branch%3Amaster] {nbsp}
 image:https://img.shields.io/github/downloads/OpenBangla/OpenBangla-Keyboard/total.svg?label=GitHub%20Downloads[Github Downloads, link=https://img.shields.io/github/downloads/OpenBangla/OpenBangla-Keyboard/total.svg?label=GitHub%20Downloads] {nbsp}
-image:https://img.shields.io/bintray/dt/openbangla/ubuntu/openbangla-keyboard?label=Bintray%20Ubuntu[Bintray Ubuntu repo downloads, link=https://img.shields.io/bintray/dt/openbangla/ubuntu/openbangla-keyboard?label=Bintray%20Ubuntu] {nbsp}
-image:https://img.shields.io/bintray/dt/openbangla/debian/openbangla-keyboard?label=Bintray%20Debian[Bintray Debian downloads, link=https://img.shields.io/bintray/dt/openbangla/debian/openbangla-keyboard?label=Bintray%20Debian] {nbsp}
-image:https://img.shields.io/bintray/dt/openbangla/fedora/openbangla-keyboard?label=Bintray%20Fedora[Bintray Fedora downloads, link=https://img.shields.io/bintray/dt/openbangla/fedora/openbangla-keyboard?label=Bintray%20Fedora] {nbsp}
-image:https://img.shields.io/bintray/dt/openbangla/archlinux/openbangla-keyboard?label=Bintray%20Arch%20Linux[Bintray Arch Linux downloads, link=https://img.shields.io/bintray/dt/openbangla/archlinux/openbangla-keyboard?label=Bintray%20Arch%20Linux] {nbsp}
-image:https://img.shields.io/discord/436879388362014740.svg[Discord, link=https://discord.gg/HXK7QnJ]
 
 CAUTION: প্রজেক্টটি ভাল লাগলে অনুগ্রহ করে গিটহাব 🌟 দিয়ে উৎসাহিত করুন!
 
@@ -73,44 +68,36 @@ toc::[]
 
 IMPORTANT: ওপেনবাংলা কিবোর্ড ১.৫.১ অথবা পূর্ববর্তী সংস্করণ ইনস্টল করা থাকলে https://github.com/OpenBangla/OpenBangla-Keyboard/wiki/Uninstalling-OpenBangla-Keyboard[সেটি প্রথমে আনইনস্টল করে নিন।]
 
-প্রথমে আপনার ডিস্ট্রোর জন্য আমাদের রিপজিটরি যোগ করুন, তারপর  আপনার প্যাকেজ ম্যানেজার দিয়ে স্বাভাবিকভাবে ইনস্টল করতে পারবেন।
-
-=== উবুন্টু এবং উবুন্টু-ভিত্তিক ডিস্ট্রো
-নিচের কমান্ডগুলো দিয়ে আমাদের রিপজিটরি যোগ করে নিন:
+আপনার টার্মিনাল ওপেন করুন এবং এই কমান্ডটি রান করুন আপনার bash শেলে। বিঃদ্রঃ শেলটি **BASH** হতে হতে হবে, তাছাড়া স্ক্রিপ্টটি কাজ করবে না।
 ```bash
-source /etc/os-release
-sudo sh -c "wget https://dl.bintray.com/openbangla/i/pub.key -q -O - | apt-key add -"
-sudo sh -c "wget https://dl.bintray.com/openbangla/i/ubuntu.conf -q -O - | sed s/@NAME@/$UBUNTU_CODENAME/ > /etc/apt/sources.list.d/openbangla.list"
-sudo apt update
-sudo apt install openbangla-keyboard
+bash -c "$(wget -q https://raw.githubusercontent.com/OpenBangla/OpenBangla-Keyboard/master/tools/install.sh -O -)"
 ```
 
-=== ডেবিয়ান এবং উবুন্টু-ভিত্তিক ডিস্ট্রো
-নিচের কমান্ডগুলো দিয়ে আমাদের রিপজিটরি যোগ করে নিন:
-```bash
-source /etc/os-release
-sudo sh -c "wget https://dl.bintray.com/openbangla/i/pub.key -q -O - | apt-key add -"
-sudo sh -c "wget https://dl.bintray.com/openbangla/i/debian.conf  -q -O - | sed s/@NAME@/$VERSION_CODENAME/ > /etc/apt/sources.list.d/openbangla.list"
-sudo apt update
-sudo apt install openbangla-keyboard
-```
+যদি এতে আপনার কাজ না হয় তাহলে দয়া করে একটি https://github.com/OpenBangla/OpenBangla-Keyboard/issues[ইস্যু] তৈরি করুন। এমতাবস্থায় https://github.com/OpenBangla/OpenBangla-Keyboard/wiki/Installing-OpenBangla-Keyboard[উইকি] থেকে ডিস্ট্রো-ভেদে ইন্সটল নির্দেশাবলী দেখে নিতে পারেন।
 
-=== ফেদোরা
-নিচের কমান্ডগুলো দিয়ে আমাদের রিপজিটরি যোগ করে নিন:
-```bash
-sudo rpm --import https://dl.bintray.com/openbangla/i/pub.key
-sudo sh -c "curl https://dl.bintray.com/openbangla/i/fedora.conf > /etc/yum.repos.d/openbangla.repo"
-sudo dnf install openbangla-keyboard
-```
+=== আর্চলিনাক্স ভিত্তিক ডিস্ট্রো
+Arch User Repository(AUR) তে ওপেনবাংলা কিবোর্ডের দুটো প্যাকেজ রয়েছে। `openbangla-keyboard` ব্যবহার করুন যদি আপনি সোর্স থেকে প্যাকেজটি তৈরি এবং ইন্সটল করতে চান। অথবা `openbangla-keyboard-bin` ব্যবহার করুন যদি আপনি বাইনারি প্যাকেজটি ব্যবহার করতে চান যেটি আর্চলিনাক্স ভিত্তিক ডিস্ট্রো গুলোর জন্য প্যাকেজটির মেইন্টেইনার তৈরি করেছেন। আপনি আপনার পছন্দের AUR হেল্পার ব্যবহার করে একটি কম্যান্ডের মাধ্যমেই ইন্সটল করতে পারবেন। কিছু জনপ্রিয় টুলের উদাহরণ:
 
-=== আর্চলিনাক্স
-নিচের কমান্ডগুলো দিয়ে আমাদের রিপজিটরি যোগ করে নিন:
+==== `openbangla-keyboard`
+* `$ pacaur -S openbangla-keyboard`
+* `$ yay -S openbangla-keyboard`
+* `$ yaourt -S openbangla-keyboard`
+
+==== `openbangla-keyboard-bin`
+* `$ pacaur -S openbangla-keyboard-bin`
+* `$ yay -S openbangla-keyboard-bin`
+* `$ yaourt -S openbangla-keyboard-bin`
+
+অথবা ম্যানুয়ালি ইন্সটল করুন:
 ```bash
-sudo sh -c "curl https://dl.bintray.com/openbangla/i/pub.key | pacman-key -a -"
-sudo pacman-key --lsign-key "openbanglateam@gmail.com"
-sudo sh -c "curl https://dl.bintray.com/openbangla/i/archlinux.conf >> /etc/pacman.conf"
-sudo pacman -Syy
-sudo pacman -S openbangla-keyboard
+sudo pacman -S base-devel git
+git clone https://aur.archlinux.org/openbangla-keyboard.git
+cd openbangla-keyboard
+makepkg -risc
+```
+আর্চলিনাক্স এর জন্য আমরা `.pkg.tar.zst` প্যাকেজও বিতরণ করে থাকি, যেটা আপনি https://github.com/OpenBangla/OpenBangla-Keyboard/releases[রিলিজেস] পেইজ থেকে ডাউনলোড করে ইন্সটল করতে পারবেন আপনার সিস্টেমে নিম্নলিখিত কমান্ডটি রান করে:
+```bash
+$ sudo pacman -U package.pkg.tar.zst
 ```
 
 === অন্যান্য

--- a/tools/build.sh
+++ b/tools/build.sh
@@ -44,8 +44,8 @@ if [[ $DIST =~ ^(ubuntu|debian) ]]; then
     apt-get -qq update
     apt-get -y install git
     # this is to read distro codename from filename during deployment
-    CODENAME=$(cat /etc/os-release | grep "VERSION_CODENAME" | cut -d= -f2)
-    DIST="${DIST}-${CODENAME}"
+    #CODENAME=$(cat /etc/os-release | grep "VERSION_CODENAME" | cut -d= -f2)
+    #DIST="${DIST}-${CODENAME}"
     BUILDFUNC=makeDeb
 elif [[ $DIST =~ ^fedora ]]; then
     dnf -y --allowerasing distro-sync

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 ## MUST: Always update this whenever a new version is released. Also remember to update download URLs if needed
-APP_VERSION=1.5.1
+APP_VERSION=2.0.0
 URL_STUB="https://github.com/OpenBangla/OpenBangla-Keyboard/releases/download/${APP_VERSION}"
 
 cat <<"EOF"
@@ -60,7 +60,7 @@ case $DISTRO_NAME in
    	VERSION_ID=$(grep DISTRIB_RELEASE /etc/upstream-release/lsb-release|cut -d= -f2)
   fi
 	  case ${VERSION_ID%%.*} in
-	  	20|19|18|16) VERSION_ID=${VERSION_ID%%.*}.04;UBUNTU_SUPPORTED=1;;
+	  	21|20|18) VERSION_ID=${VERSION_ID%%.*}.04;UBUNTU_SUPPORTED=1;;
 	  	*) echo "This Ubuntu release \"$VERSION_ID\" is too young or too old for me to handle";exit 1;;
 	  esac
   if [[ $UBUNTU_SUPPORTED = 1 ]]; then
@@ -72,12 +72,12 @@ case $DISTRO_NAME in
   fi
   ;;
 ("arch")
-  wget -q --show-progress "${URL_STUB}/OpenBangla-Keyboard_${APP_VERSION}-archlinux.pkg.tar.xz" -O /tmp/OpenBangla.pkg.tar.xz
+  wget -q --show-progress "${URL_STUB}/OpenBangla-Keyboard_${APP_VERSION}-archlinux.pkg.tar.zst" -O /tmp/OpenBangla.pkg.tar.zst
   sudo pacman -U /tmp/OpenBangla.pkg.tar.xz
   ;;
 ("fedora")
   # fedora version check ?
-  wget -q --show-progress "${URL_STUB}/OpenBangla-Keyboard_${APP_VERSION}-fedora28.rpm" -O /tmp/OpenBangla.rpm
+  wget -q --show-progress "${URL_STUB}/OpenBangla-Keyboard_${APP_VERSION}-fedora33.rpm" -O /tmp/OpenBangla.rpm
   sudo dnf install /tmp/OpenBangla.rpm
   ;;
 (*)


### PR DESCRIPTION
Bintray will be not available by May 1st. Unfortunately, we don't have any other way than suggesting to use `install.sh` to the users to download & install OBK easily.

* Have to update the Releases page with new packages and rename some packages to match with the `install.sh` package name convention.

cc @Adyel @bdeshi @ahmubashshir review, please.

Can we add debian disrto detection in `install.sh` as we're now building packages for debian also?