### PR TITLE
Build system configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,6 @@ jobs:
         run: |
           mkdir build
           cd build
-          cmake ..
+          cmake .. -DENABLE_IBUS=ON -DENABLE_FCITX=ON
           make
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,23 +53,34 @@ if(OS_LINUX)
 
     ## Set Directories for installing and storing files
     set(CMAKE_INSTALL_PREFIX "/usr")
-    set(BIN_DIR "${CMAKE_INSTALL_PREFIX}/bin")
-    set(DATADIR "${CMAKE_INSTALL_PREFIX}/share")
-    set(LIBEXECDIR "${CMAKE_INSTALL_PREFIX}/libexec")
+    if(NOT DEFINED BIN_DIR)
+        set(BIN_DIR "${CMAKE_INSTALL_PREFIX}/bin")
+    endif()
+    if(NOT DEFINED DATADIR)
+        set(DATADIR "${CMAKE_INSTALL_PREFIX}/share")
+    endif()
+    if(NOT DEFINED LIBEXECDIR)
+        set(LIBEXECDIR "${CMAKE_INSTALL_PREFIX}/libexec")
+    endif()
     set(PROJECT_DATADIR "${DATADIR}/openbangla-keyboard")
     add_definitions(-DPROJECT_DATADIR="${PROJECT_DATADIR}")
+    add_definitions(-DBIN_DIR="${BIN_DIR}")
     add_definitions(-DLIBEXECDIR="${LIBEXECDIR}")
 
     include(FindPkgConfig)
     find_package(PkgConfig)
 
-    ## Find iBus ##
-    pkg_check_modules(IBUS ibus-1.0)
-    ## Find Fcitx ##
-    find_package(Fcitx5Core 5.0.5)
+    option(ENABLE_IBUS "Enable IBus support" On)
+    option(ENABLE_FCITX "Enable Fcitx support" OFF)
 
-    if((NOT IBUS_FOUND) AND (NOT Fcitx5Core_FOUND))
-        message(FATAL_ERROR "Both iBus & Fcitx development library was not found!\nPlease atleast install iBus or Fcitx development library.")
+    ## Find iBus ##
+    if(ENABLE_IBUS)
+        pkg_check_modules(IBUS REQUIRED ibus-1.0)
+    endif()
+
+    ## Find Fcitx ##
+    if(ENABLE_FCITX)
+        find_package(Fcitx5Core 5.0.5 REQUIRED)
     endif()
 
     ## Find zstd ##

--- a/data/openbangla-keyboard.desktop.in
+++ b/data/openbangla-keyboard.desktop.in
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Name=OpenBangla Keyboard
 Comment=An OpenSource, Unicode compliant Bengali Input Method.
-Exec=@LIBEXECDIR@/openbangla-keyboard/openbangla-gui %f
+Exec=@BIN_DIR@/openbangla-gui %f
 Icon=openbangla-keyboard
 Type=Application
 Categories=Utility;Application;

--- a/src/engine/CMakeLists.txt
+++ b/src/engine/CMakeLists.txt
@@ -3,11 +3,11 @@ if (OS_LINUX)
     ## Platform is Linux
     add_subdirectory(common)
 
-    if (IBUS_FOUND)
+    if (ENABLE_IBUS)
         add_subdirectory(ibus)
     endif()
 
-    if (Fcitx5Core_FOUND)
+    if (ENABLE_FCITX)
         add_subdirectory(fcitx)
     endif()
 endif (OS_LINUX)

--- a/src/engine/fcitx/openbangla.h
+++ b/src/engine/fcitx/openbangla.h
@@ -37,7 +37,7 @@ class OpenBanglaState;
 FCITX_CONFIGURATION(OpenBanglaConfig,
                     ExternalOption config{
                         this, "OpenBanglaKeyboard", _("OpenBangla Keyboard"),
-                        LIBEXECDIR "/openbangla-keyboard/openbangla-gui"};);
+                        BIN_DIR "/openbangla-gui"};);
 
 class OpenBanglaEngine final : public InputMethodEngine {
 public:

--- a/src/frontend/CMakeLists.txt
+++ b/src/frontend/CMakeLists.txt
@@ -30,4 +30,4 @@ add_executable(openbangla-gui ${SRC_MAIN} ${SRC_GUI})
 target_link_libraries(openbangla-gui ${LINK_LIBS})
 
 install(TARGETS openbangla-gui
-        RUNTIME DESTINATION ${LIBEXECDIR}/openbangla-keyboard)
+        RUNTIME DESTINATION ${BIN_DIR})


### PR DESCRIPTION
Now it's possible to override `BIN_DIR`, `DATADIR` & `LIBEXECDIR` and building IM backends on the basis of build-time variables, Passing CMake the `-DENABLE_IBUS=ON` flag will build the `ibus` backend(Default) while passing the `-DENABLE_FCITX` flag will build the `fcitx` backend. I think this will help to split the package as we had discussed on #219 

cc @gunnarhj  @ahmubashshir 