### PR TITLE
View the TopBar according to the last state of it 

### DIFF
--- a/src/frontend/TopBar.cpp
+++ b/src/frontend/TopBar.cpp
@@ -72,6 +72,8 @@ TopBar::TopBar(bool darkIcon, QWidget *parent) :
   SetupTrayIcon();
   DataMigration();
 
+  //this->setVisible(gSettings->getTopBarVisibility());
+  
 #ifndef NO_UPDATE_CHECK
   updater = QSimpleUpdater::getInstance();
 
@@ -92,10 +94,12 @@ TopBar::~TopBar() {
 
   delete ui;
 }
-
+#include <QDebug>
 void TopBar::SetupTopBar() {
   this->setWindowFlags(Qt::Window | Qt::FramelessWindowHint | Qt::WindowStaysOnTopHint);
   this->setFixedSize(QSize(this->width(), this->height()));
+  qDebug() << gSettings->getTopBarVisibility();
+  
 
   if (gSettings->getTopBarWindowPosition() == QPoint(0, 0)) {
     int width = this->frameGeometry().width();
@@ -305,8 +309,19 @@ void TopBar::on_buttonIcon_clicked() {
   }
 }
 
+void TopBar::showEvent(QShowEvent *event) {
+  if(gSettings->getTopBarVisibility()) {
+    event->accept();
+    qDebug() << "accepted";
+  } else {
+    event->ignore();
+    qDebug() << "ignored";
+  }
+}
+
 void TopBar::closeEvent(QCloseEvent *event) {
   gSettings->setTopBarWindowPosition(this->pos());
+  gSettings->setTopBarVisibility(this->isVisible());
   event->accept();
 }
 
@@ -346,6 +361,7 @@ void TopBar::on_buttonSetLayout_clicked() {
 
 void TopBar::on_buttonShutdown_clicked() {
   gSettings->setTopBarWindowPosition(this->pos());
+  gSettings->setTopBarVisibility(this->isVisible());
   QApplication::exit();
 }
 

--- a/src/frontend/TopBar.cpp
+++ b/src/frontend/TopBar.cpp
@@ -105,7 +105,6 @@ TopBar::~TopBar() {
 void TopBar::SetupTopBar() {
   this->setWindowFlags(Qt::Window | Qt::FramelessWindowHint | Qt::WindowStaysOnTopHint);
   this->setFixedSize(QSize(this->width(), this->height()));
-  
 
   if (gSettings->getTopBarWindowPosition() == QPoint(0, 0)) {
     int width = this->frameGeometry().width();

--- a/src/frontend/TopBar.cpp
+++ b/src/frontend/TopBar.cpp
@@ -46,13 +46,13 @@ TopBar::TopBar(bool darkIcon, QWidget *parent) :
   ui->setupUi(this);
 
   gLayout = new Layout();
-  gSettings = new Settings();
 
   if(darkIcon) {
     m_iconTheme = "white";
   } else {
     m_iconTheme = "black";
   }
+
   /* Dialogs */
   aboutDialog = new AboutDialog(Q_NULLPTR);
   layoutViewer = new LayoutViewer(m_iconTheme, Q_NULLPTR);
@@ -71,8 +71,6 @@ TopBar::TopBar(bool darkIcon, QWidget *parent) :
   SetupPopupMenus();
   SetupTrayIcon();
   DataMigration();
-
-  //this->setVisible(gSettings->getTopBarVisibility());
   
 #ifndef NO_UPDATE_CHECK
   updater = QSimpleUpdater::getInstance();
@@ -94,11 +92,10 @@ TopBar::~TopBar() {
 
   delete ui;
 }
-#include <QDebug>
+
 void TopBar::SetupTopBar() {
   this->setWindowFlags(Qt::Window | Qt::FramelessWindowHint | Qt::WindowStaysOnTopHint);
   this->setFixedSize(QSize(this->width(), this->height()));
-  qDebug() << gSettings->getTopBarVisibility();
   
 
   if (gSettings->getTopBarWindowPosition() == QPoint(0, 0)) {
@@ -181,10 +178,11 @@ void TopBar::SetupTrayIcon() {
   traySettings = new QAction("Settings", this);
   connect(traySettings, &QAction::triggered, this, &TopBar::on_buttonSettings_clicked);
 
-  trayTopBarVisibility = new QAction("Hide the TopBar", this);
-  if(not this->isVisible()) {
-    trayTopBarVisibility->setText("Show the TopBar");
-  }
+  trayTopBarVisibility = new QAction(
+    gSettings->getTopBarVisibility() ? "Hide the TopBar" : "Show the TopBar",
+    this
+  );
+  
   connect(trayTopBarVisibility, &QAction::triggered, [&]() {
     if(this->isVisible()) {
       this->setVisible(false);
@@ -306,16 +304,6 @@ void TopBar::on_buttonIcon_clicked() {
     point.setX(point.x() + ui->buttonIcon->geometry().x());
     point.setY(point.y() + this->height());
     iconMenu->exec(point);
-  }
-}
-
-void TopBar::showEvent(QShowEvent *event) {
-  if(gSettings->getTopBarVisibility()) {
-    event->accept();
-    qDebug() << "accepted";
-  } else {
-    event->ignore();
-    qDebug() << "ignored";
   }
 }
 

--- a/src/frontend/TopBar.cpp
+++ b/src/frontend/TopBar.cpp
@@ -71,6 +71,15 @@ TopBar::TopBar(bool darkIcon, QWidget *parent) :
   SetupPopupMenus();
   SetupTrayIcon();
   DataMigration();
+
+  uint count = gSettings->getTrayInfoCount();
+  if(count < 4 && !gSettings->getTopBarVisibility()) {
+    tray->showMessage("OpenBangla Keyboard", "Currently running in the system tray.\n"
+                      "You can use the tray icon to change keyboard layouts and other "
+                      "settings and to show the TopBar again.");
+    // Update the counter to show only the message for the first three times
+    gSettings->setTrayInfoCount(count + 1);
+  }
   
 #ifndef NO_UPDATE_CHECK
   updater = QSimpleUpdater::getInstance();

--- a/src/frontend/TopBar.h
+++ b/src/frontend/TopBar.h
@@ -54,7 +54,6 @@ public:
   ~TopBar() override;
 
 protected:
-  void showEvent(QShowEvent *event) override;
   void closeEvent(QCloseEvent *event) override;
 
   bool eventFilter(QObject *object, QEvent *event) override;

--- a/src/frontend/TopBar.h
+++ b/src/frontend/TopBar.h
@@ -54,6 +54,7 @@ public:
   ~TopBar() override;
 
 protected:
+  void showEvent(QShowEvent *event) override;
   void closeEvent(QCloseEvent *event) override;
 
   bool eventFilter(QObject *object, QEvent *event) override;

--- a/src/frontend/main.cpp
+++ b/src/frontend/main.cpp
@@ -22,9 +22,12 @@
 #include <QCommandLineOption>
 #include "TopBar.h"
 #include "SingleInstance.h"
+#include "Settings.h"
 
 int main(int argc, char *argv[]) {
   QApplication app(argc, argv);
+  gSettings = new Settings();
+
   app.setApplicationName("OpenBangla Keyboard");
   app.setApplicationVersion(PROJECT_VERSION);
 
@@ -54,7 +57,7 @@ int main(int argc, char *argv[]) {
 
   TopBar w(parser.isSet(darkIcon));
   w.show();
-  if (parser.isSet(startInTray)) {
+  if (parser.isSet(startInTray) || !gSettings->getTopBarVisibility()) {
     w.setVisible(false);
   }
   return app.exec();

--- a/src/shared/Settings.cpp
+++ b/src/shared/Settings.cpp
@@ -42,6 +42,16 @@ QPoint Settings::getTopBarWindowPosition() {
   return setting->value("window/positions/TopBar", QPoint(0, 0)).toPoint();
 }
 
+void Settings::setTopBarVisibility(bool b) {
+  setting->setValue("window/visibility/TopBar", b);
+  setting->sync();
+}
+
+bool Settings::getTopBarVisibility() {
+  setting->sync();
+  return setting->value("window/visibility/TopBar", true).toBool();
+}
+
 void Settings::setLayoutViewerWindowPosition(QPoint pos) {
   setting->setValue("window/positions/LayoutViewer", pos);
   setting->sync();

--- a/src/shared/Settings.cpp
+++ b/src/shared/Settings.cpp
@@ -52,6 +52,16 @@ bool Settings::getTopBarVisibility() {
   return setting->value("window/visibility/TopBar", true).toBool();
 }
 
+void Settings::setTrayInfoCount(uint b) {
+  setting->setValue("settings/TrayInfoCount", b);
+  setting->sync();
+}
+
+uint Settings::getTrayInfoCount() {
+  setting->sync();
+  return setting->value("settings/TrayInfoCount", 0).toUInt();
+}
+
 void Settings::setLayoutViewerWindowPosition(QPoint pos) {
   setting->setValue("window/positions/LayoutViewer", pos);
   setting->sync();

--- a/src/shared/Settings.h
+++ b/src/shared/Settings.h
@@ -40,6 +40,10 @@ public:
 
   bool getTopBarVisibility();
 
+  void setTrayInfoCount(uint b);
+
+  uint getTrayInfoCount();
+
   void setLayoutViewerWindowPosition(QPoint pos);
 
   QPoint getLayoutViewerWindowPosition();

--- a/src/shared/Settings.h
+++ b/src/shared/Settings.h
@@ -36,6 +36,10 @@ public:
 
   QPoint getTopBarWindowPosition();
 
+  void setTopBarVisibility(bool b);
+
+  bool getTopBarVisibility();
+
   void setLayoutViewerWindowPosition(QPoint pos);
 
   QPoint getLayoutViewerWindowPosition();


### PR DESCRIPTION
This implements saving the visibility of the TopBar while closing it and views the TopBar in the same way(hidden or shown) in the next run. If the TopBar is hidden while starting, it will notify the user of running in the system tray for the first three times.
![Tray Message OBK](https://user-images.githubusercontent.com/9459891/124366610-dbfb6400-dc72-11eb-8898-6a97a78fd7ae.png)
