### PR TITLE
Update the `riti` submodule

### DIFF
--- a/src/engine/fcitx/openbangla.cpp
+++ b/src/engine/fcitx/openbangla.cpp
@@ -378,40 +378,39 @@ bool booleanValue(const RawConfig &config, const std::string &path,
 
 void OpenBanglaEngine::populateConfig(const RawConfig &config) {
   // Keep sync with Settings.cpp
-  std::string layoutPath =
-      "/usr/share/openbangla-keyboard/layouts/avrophonetic.json";
+  std::string layoutPath = "avro_phonetic";
   if (auto *path = config.valueByPath("layout/path")) {
     layoutPath = *path;
   }
   const bool showCWPhonetic =
       booleanValue(config, "settings/CandidateWin\\Phonetic", true);
-  const bool includeEnglishPrevWin =
-      booleanValue(config, "settings/PreviewWin\\IncludeEnglishPhonetic", true);
+  const bool includeEnglish =
+      booleanValue(config, "settings/PreviewWin\\IncludeEnglish", true);
   const bool showPrevWinFixed =
       booleanValue(config, "settings/FixedLayout\\ShowPrevWin", true);
-  const bool includeEnglishFixed =
-      booleanValue(config, "settings/PreviewWin\\IncludeEnglishFixed", true);
   const bool autoVowelFormFixed =
       booleanValue(config, "settings/FixedLayout\\AutoVowelForm", true);
   const bool autoChandraPosFixed =
       booleanValue(config, "settings/FixedLayout\\AutoChandraPos", true);
   const bool traditionalKarFixed =
       booleanValue(config, "settings/FixedLayout\\TraditionalKar", false);
+  const bool oldKarOrder =
+      booleanValue(config, "settings/FixedLayout\\OldKarOrder", false);
   const bool oldReph =
       booleanValue(config, "settings/FixedLayout\\OldReph", true);
   const bool numberPadFixed =
       booleanValue(config, "settings/FixedLayout\\NumberPad", true);
 
   riti_config_set_layout_file(cfg_.get(), layoutPath.data());
+  riti_config_set_suggestion_include_english(cfg_.get(), includeEnglish);
   riti_config_set_phonetic_suggestion(cfg_.get(), showCWPhonetic);
-  riti_config_set_phonetic_include_english(cfg_.get(), includeEnglishPrevWin);
   riti_config_set_database_dir(cfg_.get(),
                                "/usr/share/openbangla-keyboard/data");
   riti_config_set_fixed_suggestion(cfg_.get(), showPrevWinFixed);
-  riti_config_set_fixed_include_english(cfg_.get(), includeEnglishFixed);
   riti_config_set_fixed_auto_vowel(cfg_.get(), autoVowelFormFixed);
   riti_config_set_fixed_auto_chandra(cfg_.get(), autoChandraPosFixed);
   riti_config_set_fixed_traditional_kar(cfg_.get(), traditionalKarFixed);
+  riti_config_set_fixed_old_kar_order(cfg_.get(), oldKarOrder);
   riti_config_set_fixed_old_reph(cfg_.get(), oldReph);
   riti_config_set_fixed_numpad(cfg_.get(), numberPadFixed);
 

--- a/src/engine/ibus/main.cpp
+++ b/src/engine/ibus/main.cpp
@@ -17,21 +17,21 @@ static Suggestion *suggestion = nullptr;
 static bool altGr = false;
 
 void update_with_settings() {
-    riti_config_set_layout_file(config, gSettings->getLayoutPath().toStdString().data());
-    riti_config_set_phonetic_suggestion(config, gSettings->getShowCWPhonetic());
-    riti_config_set_phonetic_include_english(config, gSettings->getIncludeEnglishPhonetic());
-    riti_config_set_database_dir(config, DatabasePath().toStdString().data());
-    riti_config_set_fixed_suggestion(config, gSettings->getShowPrevWinFixed());
-    riti_config_set_fixed_include_english(config, gSettings->getIncludeEnglishFixed());
-    riti_config_set_fixed_auto_vowel(config, gSettings->getAutoVowelFormFixed());
-    riti_config_set_fixed_auto_chandra(config, gSettings->getAutoChandraPosFixed());
-    riti_config_set_fixed_traditional_kar(config, gSettings->getTraditionalKarFixed());
-    riti_config_set_fixed_old_reph(config, gSettings->getOldReph());
-    riti_config_set_fixed_numpad(config, gSettings->getNumberPadFixed());
+  riti_config_set_layout_file(config, gSettings->getLayoutPath().toStdString().data());
+  riti_config_set_suggestion_include_english(config, gSettings->getSuggestionIncludeEnglish());
+  riti_config_set_phonetic_suggestion(config, gSettings->getShowCWPhonetic());
+  riti_config_set_database_dir(config, DatabasePath().toStdString().data());
+  riti_config_set_fixed_suggestion(config, gSettings->getShowPrevWinFixed());
+  riti_config_set_fixed_auto_vowel(config, gSettings->getAutoVowelFormFixed());
+  riti_config_set_fixed_auto_chandra(config, gSettings->getAutoChandraPosFixed());
+  riti_config_set_fixed_traditional_kar(config, gSettings->getTraditionalKarFixed());
+  riti_config_set_fixed_old_kar_order(config, gSettings->getFixedOldKarOrder());
+  riti_config_set_fixed_old_reph(config, gSettings->getOldReph());
+  riti_config_set_fixed_numpad(config, gSettings->getNumberPadFixed());
 
-    if(table != nullptr) {
-      ibus_lookup_table_set_orientation(table, gSettings->getCandidateWinHorizontal() ? IBUS_ORIENTATION_HORIZONTAL : IBUS_ORIENTATION_VERTICAL);
-    }
+  if(table != nullptr) {
+    ibus_lookup_table_set_orientation(table, gSettings->getCandidateWinHorizontal() ? IBUS_ORIENTATION_HORIZONTAL : IBUS_ORIENTATION_VERTICAL);
+  }
 }
 
 void engine_update_preedit() {

--- a/src/frontend/Layout.cpp
+++ b/src/frontend/Layout.cpp
@@ -126,5 +126,10 @@ void Layout::setLayout(QString name) {
   // Get the actual path and load the layout
   loadLayout(layoutMap[name]);
   gSettings->setLayoutName(name);
-  gSettings->setLayoutPath(layoutMap[name]);
+  if(lD.type == Layout_Phonetic) {
+    // Hardcoded Avro Phonetic setting.
+    gSettings->setLayoutPath("avro_phonetic");
+  } else {
+    gSettings->setLayoutPath(layoutMap[name]);
+  }
 }

--- a/src/frontend/SettingsDialog.cpp
+++ b/src/frontend/SettingsDialog.cpp
@@ -29,6 +29,7 @@ SettingsDialog::SettingsDialog(QWidget *parent) :
   autoCorrectDialog = new AutoCorrectDialog(this);
 
   ui->cmbOrientation->insertItems(0, {"Horizontal", "Vertical"});
+  ui->cmbKarOrder->insertItems(0, {"Modern", "Old"});
 
 #ifdef NO_UPDATE_CHECK
   ui->lblUpdateCheck->hide();
@@ -45,18 +46,19 @@ SettingsDialog::~SettingsDialog() {
 }
 
 void SettingsDialog::implementSignals() {
-  // Phonetic Keyboard Layout Group.
-  connect(ui->btnSuggestionPhonetic, &QPushButton::toggled, [=](bool checked) {
-    ui->btnSuggestionPhonetic->setText(checked ? "On" : "Off");
-    // Control other Preview window related settings.
-    ui->btnIncludeEnglishPrevWin->setEnabled(checked);
-    ui->btnACUpdate->setEnabled(checked);
-  });
+  // General Group
   connect(ui->btnEnterClosePW, &QPushButton::toggled, [=](bool checked) {
     ui->btnEnterClosePW->setText(checked ? "On" : "Off");
   });
   connect(ui->btnIncludeEnglishPrevWin, &QPushButton::toggled, [=](bool checked) {
     ui->btnIncludeEnglishPrevWin->setText(checked ? "On" : "Off");
+  });
+  
+  // Phonetic Keyboard Layout Group.
+  connect(ui->btnSuggestionPhonetic, &QPushButton::toggled, [=](bool checked) {
+    ui->btnSuggestionPhonetic->setText(checked ? "On" : "Off");
+    // Control other Preview window related settings.
+    ui->btnACUpdate->setEnabled(checked);
   });
   connect(ui->btnACUpdate, &QPushButton::clicked, [=]() {
     autoCorrectDialog->open();
@@ -65,10 +67,6 @@ void SettingsDialog::implementSignals() {
   // Fixed Keyboard Layout Group.
   connect(ui->btnSuggestionFixed, &QPushButton::toggled, [=](bool checked) {
     ui->btnSuggestionFixed->setText(checked ? "On" : "Off");
-    ui->btnIncludeEnglishFixed->setEnabled(checked);
-  });
-  connect(ui->btnIncludeEnglishFixed, &QPushButton::toggled, [=](bool checked) {
-    ui->btnIncludeEnglishFixed->setText(checked ? "On" : "Off");
   });
   connect(ui->btnAutoVowel, &QPushButton::toggled, [=](bool checked) {
     ui->btnAutoVowel->setText(checked ? "On" : "Off");
@@ -101,17 +99,19 @@ void SettingsDialog::implementSignals() {
 }
 
 void SettingsDialog::updateSettings() {
-  // Phonetic Keyboard Layout Group.
+  // General Group
   ui->btnEnterClosePW->setChecked(gSettings->getEnterKeyClosesPrevWin());
-  ui->btnSuggestionPhonetic->setChecked(gSettings->getShowCWPhonetic());
   ui->cmbOrientation->setCurrentIndex(gSettings->getCandidateWinHorizontal() ? 0 : 1);
-  ui->btnIncludeEnglishPrevWin->setChecked(gSettings->getIncludeEnglishPhonetic());
+  ui->btnIncludeEnglishPrevWin->setChecked(gSettings->getSuggestionIncludeEnglish());
+
+  // Phonetic Keyboard Layout Group.
+  ui->btnSuggestionPhonetic->setChecked(gSettings->getShowCWPhonetic());
 
   // Fixed Keyboard Layout Group.
   ui->btnSuggestionFixed->setChecked(gSettings->getShowPrevWinFixed());
-  ui->btnIncludeEnglishFixed->setChecked(gSettings->getIncludeEnglishFixed());
   ui->btnAutoVowel->setChecked(gSettings->getAutoVowelFormFixed());
   ui->btnAutoChandra->setChecked(gSettings->getAutoChandraPosFixed());
+  ui->cmbKarOrder->setCurrentIndex(gSettings->getFixedOldKarOrder() ? 1 : 0);
   ui->btnOldReph->setChecked(gSettings->getOldReph());
   ui->btnKarJoining->setChecked(gSettings->getTraditionalKarFixed());
   ui->btnNumberpad->setChecked(gSettings->getNumberPadFixed());
@@ -120,17 +120,19 @@ void SettingsDialog::updateSettings() {
 }
 
 void SettingsDialog::saveSettings() {
-  // Phonetic Keyboard Layout Group.
+  // General Group
   gSettings->setEnterKeyClosesPrevWin(ui->btnEnterClosePW->isChecked());
-  gSettings->setShowCWPhonetic(ui->btnSuggestionPhonetic->isChecked());
   gSettings->setCandidateWinHorizontal((ui->cmbOrientation->currentIndex() == 0));
-  gSettings->setIncludeEnglishPhonetic(ui->btnIncludeEnglishPrevWin->isChecked());
+  gSettings->setSuggestionIncludeEnglish(ui->btnIncludeEnglishPrevWin->isChecked());
+
+  // Phonetic Keyboard Layout Group.
+  gSettings->setShowCWPhonetic(ui->btnSuggestionPhonetic->isChecked());
 
   // Fixed Keyboard Layout Group.
   gSettings->setShowPrevWinFixed(ui->btnSuggestionFixed->isChecked());
-  gSettings->setIncludeEnglishFixed(ui->btnIncludeEnglishFixed->isChecked());
   gSettings->setAutoVowelFormFixed(ui->btnAutoVowel->isChecked());
   gSettings->setAutoChandraPosFixed(ui->btnAutoChandra->isChecked());
+  gSettings->setFixedOldKarOrder(ui->cmbKarOrder->currentIndex() == 1);
   gSettings->setOldReph(ui->btnOldReph->isChecked());
   gSettings->setTraditionalKarFixed(ui->btnKarJoining->isChecked());
   gSettings->setNumberPadFixed(ui->btnNumberpad->isChecked());

--- a/src/frontend/SettingsDialog.ui
+++ b/src/frontend/SettingsDialog.ui
@@ -30,8 +30,8 @@
           <string>General</string>
          </property>
          <layout class="QGridLayout" name="gridLayout">
-          <item row="0" column="0">
-           <widget class="QLabel" name="label">
+          <item row="1" column="0">
+           <widget class="QLabel" name="label_3">
             <property name="sizePolicy">
              <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
               <horstretch>0</horstretch>
@@ -39,7 +39,7 @@
              </sizepolicy>
             </property>
             <property name="text">
-             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Enter key only closes the preview window:&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Preview window Orientation:&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
             </property>
             <property name="alignment">
              <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
@@ -62,22 +62,6 @@
             </property>
            </widget>
           </item>
-          <item row="1" column="0">
-           <widget class="QLabel" name="label_3">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="text">
-             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Preview window Orientation:&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-            </property>
-            <property name="alignment">
-             <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-            </property>
-           </widget>
-          </item>
           <item row="1" column="1">
            <widget class="QComboBox" name="cmbOrientation">
             <property name="sizePolicy">
@@ -91,20 +75,7 @@
             </property>
            </widget>
           </item>
-          <item row="2" column="0">
-           <widget class="QLabel" name="lblUpdateCheck">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="text">
-             <string>Automatically Check for Updates:</string>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="1">
+          <item row="3" column="1">
            <widget class="QPushButton" name="btnCheckUpdate">
             <property name="sizePolicy">
              <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
@@ -120,6 +91,67 @@
             </property>
             <property name="checked">
              <bool>false</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="0">
+           <widget class="QLabel" name="lblUpdateCheck">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="text">
+             <string>Automatically Check for Updates:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="0">
+           <widget class="QLabel" name="label">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="text">
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Enter key only closes the preview window:&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="0">
+           <widget class="QLabel" name="label_5">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="text">
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Include English word in the suggestions:&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="1">
+           <widget class="QPushButton" name="btnIncludeEnglishPrevWin">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="text">
+             <string>Off</string>
+            </property>
+            <property name="checkable">
+             <bool>true</bool>
             </property>
            </widget>
           </item>
@@ -159,38 +191,6 @@
           </item>
           <item row="0" column="1">
            <widget class="QPushButton" name="btnSuggestionPhonetic">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="text">
-             <string>Off</string>
-            </property>
-            <property name="checkable">
-             <bool>true</bool>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="0">
-           <widget class="QLabel" name="label_5">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="text">
-             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Include English word in the suggestions:&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-            </property>
-            <property name="alignment">
-             <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="1">
-           <widget class="QPushButton" name="btnIncludeEnglishPrevWin">
             <property name="sizePolicy">
              <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
               <horstretch>0</horstretch>
@@ -254,8 +254,21 @@
         <string>Fixed Keyboard Layout</string>
        </property>
        <layout class="QGridLayout" name="gridLayout_3">
-        <item row="5" column="1">
-         <widget class="QPushButton" name="btnKarJoining">
+        <item row="3" column="0">
+         <widget class="QLabel" name="label_7">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="text">
+           <string>Automatic Chandrabindu Position fix:</string>
+          </property>
+         </widget>
+        </item>
+        <item row="7" column="1">
+         <widget class="QPushButton" name="btnNumberpad">
           <property name="sizePolicy">
            <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
             <horstretch>0</horstretch>
@@ -270,8 +283,8 @@
           </property>
          </widget>
         </item>
-        <item row="4" column="0">
-         <widget class="QLabel" name="label_8">
+        <item row="2" column="0">
+         <widget class="QLabel" name="label_6">
           <property name="sizePolicy">
            <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
             <horstretch>0</horstretch>
@@ -279,7 +292,7 @@
            </sizepolicy>
           </property>
           <property name="text">
-           <string>Old Style Reph:</string>
+           <string>Automatic Vowel Forming:</string>
           </property>
          </widget>
         </item>
@@ -299,34 +312,8 @@
           </property>
          </widget>
         </item>
-        <item row="5" column="0">
-         <widget class="QLabel" name="label_9">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="text">
-           <string>Traditional Kar Joining:</string>
-          </property>
-         </widget>
-        </item>
-        <item row="6" column="0">
-         <widget class="QLabel" name="label_10">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="text">
-           <string>Bengali in NumberPad:</string>
-          </property>
-         </widget>
-        </item>
         <item row="6" column="1">
-         <widget class="QPushButton" name="btnNumberpad">
+         <widget class="QPushButton" name="btnKarJoining">
           <property name="sizePolicy">
            <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
             <horstretch>0</horstretch>
@@ -341,14 +328,20 @@
           </property>
          </widget>
         </item>
-        <item row="0" column="0">
-         <widget class="QLabel" name="label_12">
+        <item row="5" column="0">
+         <widget class="QLabel" name="label_8">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
           <property name="text">
-           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show suggestions:&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+           <string>Old Style Reph:</string>
           </property>
          </widget>
         </item>
-        <item row="4" column="1">
+        <item row="5" column="1">
          <widget class="QPushButton" name="btnOldReph">
           <property name="sizePolicy">
            <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
@@ -361,48 +354,6 @@
           </property>
           <property name="checkable">
            <bool>true</bool>
-          </property>
-         </widget>
-        </item>
-        <item row="3" column="1">
-         <widget class="QPushButton" name="btnAutoChandra">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="text">
-           <string>Off</string>
-          </property>
-          <property name="checkable">
-           <bool>true</bool>
-          </property>
-         </widget>
-        </item>
-        <item row="3" column="0">
-         <widget class="QLabel" name="label_7">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="text">
-           <string>Automatic Chandrabindu Position fix:</string>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="0">
-         <widget class="QLabel" name="label_6">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="text">
-           <string>Automatic Vowel Forming:</string>
           </property>
          </widget>
         </item>
@@ -422,15 +373,34 @@
           </property>
          </widget>
         </item>
-        <item row="1" column="0">
-         <widget class="QLabel" name="label_4">
+        <item row="7" column="0">
+         <widget class="QLabel" name="label_10">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
           <property name="text">
-           <string>Include English word in the suggestions:</string>
+           <string>Bengali in NumberPad:</string>
           </property>
          </widget>
         </item>
-        <item row="1" column="1">
-         <widget class="QPushButton" name="btnIncludeEnglishFixed">
+        <item row="0" column="0">
+         <widget class="QLabel" name="label_12">
+          <property name="text">
+           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show suggestions:&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+          </property>
+         </widget>
+        </item>
+        <item row="3" column="1">
+         <widget class="QPushButton" name="btnAutoChandra">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
           <property name="text">
            <string>Off</string>
           </property>
@@ -438,6 +408,29 @@
            <bool>true</bool>
           </property>
          </widget>
+        </item>
+        <item row="6" column="0">
+         <widget class="QLabel" name="label_9">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="text">
+           <string>Traditional Kar Joining:</string>
+          </property>
+         </widget>
+        </item>
+        <item row="4" column="0">
+         <widget class="QLabel" name="label_4">
+          <property name="text">
+           <string>Kar Typing Order</string>
+          </property>
+         </widget>
+        </item>
+        <item row="4" column="1">
+         <widget class="QComboBox" name="cmbKarOrder"/>
         </item>
        </layout>
       </widget>

--- a/src/frontend/SettingsDialog.ui
+++ b/src/frontend/SettingsDialog.ui
@@ -30,7 +30,7 @@
           <string>General</string>
          </property>
          <layout class="QGridLayout" name="gridLayout">
-          <item row="1" column="0">
+          <item row="2" column="0">
            <widget class="QLabel" name="label_3">
             <property name="sizePolicy">
              <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
@@ -46,23 +46,7 @@
             </property>
            </widget>
           </item>
-          <item row="0" column="1">
-           <widget class="QPushButton" name="btnEnterClosePW">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="text">
-             <string>Off</string>
-            </property>
-            <property name="checkable">
-             <bool>true</bool>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="1">
+          <item row="2" column="1">
            <widget class="QComboBox" name="cmbOrientation">
             <property name="sizePolicy">
              <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
@@ -75,7 +59,20 @@
             </property>
            </widget>
           </item>
-          <item row="3" column="1">
+          <item row="4" column="0">
+           <widget class="QLabel" name="lblUpdateCheck">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="text">
+             <string>Automatically Check for Updates:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="1">
            <widget class="QPushButton" name="btnCheckUpdate">
             <property name="sizePolicy">
              <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
@@ -94,20 +91,7 @@
             </property>
            </widget>
           </item>
-          <item row="3" column="0">
-           <widget class="QLabel" name="lblUpdateCheck">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="text">
-             <string>Automatically Check for Updates:</string>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="0">
+          <item row="1" column="0">
            <widget class="QLabel" name="label">
             <property name="sizePolicy">
              <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
@@ -123,7 +107,23 @@
             </property>
            </widget>
           </item>
-          <item row="2" column="0">
+          <item row="1" column="1">
+           <widget class="QPushButton" name="btnEnterClosePW">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="text">
+             <string>Off</string>
+            </property>
+            <property name="checkable">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="0">
            <widget class="QLabel" name="label_5">
             <property name="sizePolicy">
              <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
@@ -139,7 +139,7 @@
             </property>
            </widget>
           </item>
-          <item row="2" column="1">
+          <item row="0" column="1">
            <widget class="QPushButton" name="btnIncludeEnglishPrevWin">
             <property name="sizePolicy">
              <sizepolicy hsizetype="Minimum" vsizetype="Fixed">

--- a/src/shared/Settings.cpp
+++ b/src/shared/Settings.cpp
@@ -89,7 +89,7 @@ void Settings::setLayoutPath(QString path) {
 
 QString Settings::getLayoutPath() {
   setting->sync();
-  return setting->value("layout/path", AvroPhoneticLayoutPath()).toString();
+  return setting->value("layout/path", "avro_phonetic").toString();
 }
 
 void Settings::setEnterKeyClosesPrevWin(bool b) {
@@ -192,24 +192,24 @@ bool Settings::getUpdateCheck() {
   return setting->value("settings/UpdateCheck", true).toBool();
 }
 
-void Settings::setIncludeEnglishPhonetic(bool b) {
-  setting->setValue("settings/PreviewWin/IncludeEnglishPhonetic", b);
+void Settings::setSuggestionIncludeEnglish(bool b) {
+  setting->setValue("settings/PreviewWin/IncludeEnglish", b);
   setting->sync();
 }
 
-bool Settings::getIncludeEnglishPhonetic() {
+bool Settings::getSuggestionIncludeEnglish() {
   setting->sync();
-  return setting->value("settings/PreviewWin/IncludeEnglishPhonetic", true).toBool();
+  return setting->value("settings/PreviewWin/IncludeEnglish", true).toBool();
 }
 
-void Settings::setIncludeEnglishFixed(bool b) {
-  setting->setValue("settings/PreviewWin/IncludeEnglishFixed", b);
+void Settings::setFixedOldKarOrder(bool b) {
+  setting->setValue("settings/FixedLayout/OldKarOrder", b);
   setting->sync();
 }
 
-bool Settings::getIncludeEnglishFixed() {
+bool Settings::getFixedOldKarOrder() {
   setting->sync();
-  return setting->value("settings/PreviewWin/IncludeEnglishFixed", true).toBool();
+  return setting->value("settings/FixedLayout/OldKarOrder", false).toBool();
 }
 
 void Settings::setPreviousUserDataRemains(bool b) {

--- a/src/shared/Settings.h
+++ b/src/shared/Settings.h
@@ -96,13 +96,13 @@ public:
 
   bool getUpdateCheck();
 
-  void setIncludeEnglishPhonetic(bool b);
+  void setSuggestionIncludeEnglish(bool b);
 
-  bool getIncludeEnglishPhonetic();
+  bool getSuggestionIncludeEnglish();
 
-  void setIncludeEnglishFixed(bool b);
+  void setFixedOldKarOrder(bool b);
 
-  bool getIncludeEnglishFixed();
+  bool getFixedOldKarOrder();
 
   void setPreviousUserDataRemains(bool b);
 


### PR DESCRIPTION
This update of the `riti` submodule brings:
* **[`okkhor`](https://github.com/gulshan/okkhor) as the new phonetic transliteration crate**: `okkhor` is a faster implementation of Avro Phonetic by @gulshan, which is [quite faster](https://gist.github.com/mominul/3efb234767f889d88a3026fe2a01384a) than the previous implementation `rupantor`. :rocket: 
* **Fixed Method Old Kar Ordering**: This feature implemented by @NabilSnigdho enables writing in the old kar ordering aka placing kars before consonants with the fixed method layouts. :tada: 

Other change:
* Inclusion of typed English text in the suggestion list setting of both Phonetic & Fixed method is now merged into one option under the general group.
* Adds an entry for controlling the **Fixed Method Old Kar Ordering**.

![Screenshot from 2021-07-04 22-34-19](https://user-images.githubusercontent.com/9459891/124392543-0e12d180-dd18-11eb-9112-0c25adc56639.png)
