### PR TITLE
Fix Fcitx CandidateList paging issue

### DIFF
--- a/src/engine/fcitx/openbangla.cpp
+++ b/src/engine/fcitx/openbangla.cpp
@@ -57,6 +57,16 @@ public:
     int index_;
   };
 
+  class OpenBanglaCandidateList : public CommonCandidateList {
+  public:
+    void setGlobalCursorIndex(int index) {
+      int items = this->pageSize();
+      int page = index / items;
+      setPage(page);
+      CommonCandidateList::setGlobalCursorIndex(index);
+    }
+  };
+
   void selectCandidate(const std::string &text, int index) {
     if (!suggestion_) {
       return;
@@ -133,7 +143,7 @@ public:
         }
         riti_string_free(aux);
 
-        auto candidateList = std::make_unique<CommonCandidateList>();
+        auto candidateList = std::make_unique<OpenBanglaCandidateList>();
         auto len = riti_suggestion_get_length(suggestion_.get());
         for (decltype(len) i = 0; i < len; i++) {
           char *text = riti_suggestion_get_suggestion(suggestion_.get(), i);


### PR DESCRIPTION
Workaround for fixing the bug: When selecting a candidate with `fcitx::CommonCandidateList::setGlobalCursorIndex()` and the regarding index is not on the first page(assume the intended candidate is on the second page) of the candidate list, the candidate remains unselected and the first page is shown.