### PR TITLE
Update install.sh and gh-actions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,7 +11,7 @@ jobs:
     if: contains(github.event.head_commit.message, 'deploy+') || contains(github.event.head_commit.message, 'pkg+')
     strategy:
       matrix:
-        container: [ "ubuntu:18.04", "ubuntu:20.04", "ubuntu:21.04", "debian:9", "debian:10", "fedora:32", "fedora:33", "fedora:34", "archlinux:latest" ]
+        container: [ "ubuntu:18.04", "ubuntu:20.04", "ubuntu:22.04", "debian:9", "debian:10", "debian:11", "fedora:34", "fedora:35", "fedora:36", "archlinux:latest" ]
         # this list should be updated from time to time by consulting these pages:
         # https://releases.ubuntu.com/
         # https://wiki.debian.org/DebianReleases#Production_Releases

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -60,7 +60,7 @@ case $DISTRO_NAME in
    	VERSION_ID=$(grep DISTRIB_RELEASE /etc/upstream-release/lsb-release|cut -d= -f2)
   fi
 	  case ${VERSION_ID%%.*} in
-	  	21|20|18) VERSION_ID=${VERSION_ID%%.*}.04;UBUNTU_SUPPORTED=1;;
+	  	22|21|20|18) VERSION_ID=${VERSION_ID%%.*}.04;UBUNTU_SUPPORTED=1;;
 	  	*) echo "This Ubuntu release \"$VERSION_ID\" is too young or too old for me to handle";exit 1;;
 	  esac
   if [[ $UBUNTU_SUPPORTED = 1 ]]; then


### PR DESCRIPTION
Update `install.sh` and gh-actions to build packages for newer distro releases.

New distros:
* ubuntu 22.04
* debian 11
* fedora 35
* fedora 36

EOL distros have been removed from the build list.

Closes #291 

cc @bdeshi @ahmubashshir 