### PR TITLE
Smart Quoting feature

### DIFF
--- a/src/engine/fcitx/openbangla.cpp
+++ b/src/engine/fcitx/openbangla.cpp
@@ -423,6 +423,8 @@ void OpenBanglaEngine::populateConfig(const RawConfig &config) {
       booleanValue(config, "settings/FixedLayout\\NumberPad", true);
   const bool ansiOutput =
       booleanValue(config, "settings/ANSI", false);
+  const bool smartQuoting =
+      booleanValue(config, "settings/SmartQuoting", true);
 
   riti_config_set_layout_file(cfg_.get(), layoutPath.data());
   riti_config_set_suggestion_include_english(cfg_.get(), includeEnglish);
@@ -437,6 +439,7 @@ void OpenBanglaEngine::populateConfig(const RawConfig &config) {
   riti_config_set_fixed_old_reph(cfg_.get(), oldReph);
   riti_config_set_fixed_numpad(cfg_.get(), numberPadFixed);
   riti_config_set_ansi_encoding(cfg_.get(), ansiOutput);
+  riti_config_set_smart_quote(cfg_.get(), smartQuoting);
 
   candidateWinHorizontal_ =
       booleanValue(config, "settings/CandidateWin\\Horizontal", true);

--- a/src/engine/ibus/main.cpp
+++ b/src/engine/ibus/main.cpp
@@ -29,6 +29,7 @@ void update_with_settings() {
   riti_config_set_fixed_old_reph(config, gSettings->getOldReph());
   riti_config_set_fixed_numpad(config, gSettings->getNumberPadFixed());
   riti_config_set_ansi_encoding(config, gSettings->getANSIEncoding());
+  riti_config_set_smart_quote(config, gSettings->getSmartQuoting());
 
   if(table != nullptr) {
     ibus_lookup_table_set_orientation(table, gSettings->getCandidateWinHorizontal() ? IBUS_ORIENTATION_HORIZONTAL : IBUS_ORIENTATION_VERTICAL);

--- a/src/frontend/SettingsDialog.cpp
+++ b/src/frontend/SettingsDialog.cpp
@@ -54,6 +54,9 @@ void SettingsDialog::implementSignals() {
   connect(ui->btnIncludeEnglishPrevWin, &QPushButton::toggled, [=](bool checked) {
     ui->btnIncludeEnglishPrevWin->setText(checked ? "On" : "Off");
   });
+  connect(ui->btnSmartQuote, &QPushButton::toggled, [=](bool checked) {
+    ui->btnSmartQuote->setText(checked ? "On" : "Off");
+  });
   
   // Phonetic Keyboard Layout Group.
   connect(ui->btnSuggestionPhonetic, &QPushButton::toggled, [=](bool checked) {
@@ -104,6 +107,7 @@ void SettingsDialog::implementSignals() {
 void SettingsDialog::updateSettings() {
   // General Group
   ui->btnEnterClosePW->setChecked(gSettings->getEnterKeyClosesPrevWin());
+  ui->btnSmartQuote->setChecked(gSettings->getSmartQuoting());
   ui->cmbOrientation->setCurrentIndex(gSettings->getCandidateWinHorizontal() ? 0 : 1);
   ui->btnIncludeEnglishPrevWin->setChecked(gSettings->getSuggestionIncludeEnglish());
   ui->cmbEncoding->setCurrentIndex(gSettings->getANSIEncoding() ? 1 : 0);
@@ -126,6 +130,7 @@ void SettingsDialog::updateSettings() {
 void SettingsDialog::saveSettings() {
   // General Group
   gSettings->setEnterKeyClosesPrevWin(ui->btnEnterClosePW->isChecked());
+  gSettings->setSmartQuoting(ui->btnSmartQuote->isChecked());
   gSettings->setCandidateWinHorizontal((ui->cmbOrientation->currentIndex() == 0));
   gSettings->setSuggestionIncludeEnglish(ui->btnIncludeEnglishPrevWin->isChecked());
   gSettings->setANSIEncoding(ui->cmbEncoding->currentIndex() == 1);

--- a/src/frontend/SettingsDialog.ui
+++ b/src/frontend/SettingsDialog.ui
@@ -30,36 +30,33 @@
           <string>General</string>
          </property>
          <layout class="QGridLayout" name="gridLayout">
-          <item row="2" column="0">
-           <widget class="QLabel" name="label_3">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
+          <item row="4" column="0">
+           <widget class="QLabel" name="label_13">
             <property name="text">
-             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Preview window Orientation:&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-            </property>
-            <property name="alignment">
-             <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+             <string>Output Encoding:</string>
             </property>
            </widget>
           </item>
-          <item row="2" column="1">
-           <widget class="QComboBox" name="cmbOrientation">
+          <item row="1" column="1">
+           <widget class="QPushButton" name="btnEnterClosePW">
             <property name="sizePolicy">
              <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
               <horstretch>0</horstretch>
               <verstretch>0</verstretch>
              </sizepolicy>
             </property>
-            <property name="sizeAdjustPolicy">
-             <enum>QComboBox::AdjustToContentsOnFirstShow</enum>
+            <property name="text">
+             <string>Off</string>
+            </property>
+            <property name="checkable">
+             <bool>true</bool>
             </property>
            </widget>
           </item>
-          <item row="4" column="0">
+          <item row="4" column="1">
+           <widget class="QComboBox" name="cmbEncoding"/>
+          </item>
+          <item row="5" column="0">
            <widget class="QLabel" name="lblUpdateCheck">
             <property name="sizePolicy">
              <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
@@ -72,7 +69,7 @@
             </property>
            </widget>
           </item>
-          <item row="4" column="1">
+          <item row="5" column="1">
            <widget class="QPushButton" name="btnCheckUpdate">
             <property name="sizePolicy">
              <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
@@ -107,24 +104,8 @@
             </property>
            </widget>
           </item>
-          <item row="1" column="1">
-           <widget class="QPushButton" name="btnEnterClosePW">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="text">
-             <string>Off</string>
-            </property>
-            <property name="checkable">
-             <bool>true</bool>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="0">
-           <widget class="QLabel" name="label_5">
+          <item row="3" column="0">
+           <widget class="QLabel" name="label_3">
             <property name="sizePolicy">
              <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
               <horstretch>0</horstretch>
@@ -132,7 +113,7 @@
              </sizepolicy>
             </property>
             <property name="text">
-             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Include English word in the suggestions:&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Preview window Orientation:&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
             </property>
             <property name="alignment">
              <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
@@ -155,15 +136,51 @@
             </property>
            </widget>
           </item>
-          <item row="3" column="0">
-           <widget class="QLabel" name="label_13">
-            <property name="text">
-             <string>Output Encoding:</string>
+          <item row="3" column="1">
+           <widget class="QComboBox" name="cmbOrientation">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="sizeAdjustPolicy">
+             <enum>QComboBox::AdjustToContentsOnFirstShow</enum>
             </property>
            </widget>
           </item>
-          <item row="3" column="1">
-           <widget class="QComboBox" name="cmbEncoding"/>
+          <item row="0" column="0">
+           <widget class="QLabel" name="label_5">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="text">
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Include English word in the suggestions:&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="0">
+           <widget class="QLabel" name="label_14">
+            <property name="text">
+             <string>Smart Quotes:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="1">
+           <widget class="QPushButton" name="btnSmartQuote">
+            <property name="text">
+             <string>Off</string>
+            </property>
+            <property name="checkable">
+             <bool>true</bool>
+            </property>
+           </widget>
           </item>
          </layout>
         </widget>

--- a/src/shared/Settings.cpp
+++ b/src/shared/Settings.cpp
@@ -222,6 +222,16 @@ bool Settings::getANSIEncoding() {
   return setting->value("settings/ANSI", false).toBool();
 }
 
+void Settings::setSmartQuoting(bool b) {
+  setting->setValue("settings/SmartQuoting", b);
+  setting->sync();
+}
+
+bool Settings::getSmartQuoting() {
+  setting->sync();
+  return setting->value("settings/SmartQuoting", true).toBool();
+}
+
 void Settings::setPreviousUserDataRemains(bool b) {
   setting->setValue("settings/PreviousUserDataRemains", b);
   setting->sync();

--- a/src/shared/Settings.h
+++ b/src/shared/Settings.h
@@ -108,6 +108,10 @@ public:
 
   bool getANSIEncoding();
 
+  void setSmartQuoting(bool b);
+
+  bool getSmartQuoting();
+
   void setPreviousUserDataRemains(bool b);
 
   bool getPreviousUserDataRemains();


### PR DESCRIPTION
With `Kalpurush` Unicode font:
![smart quotes](https://user-images.githubusercontent.com/9459891/166911104-26463bfc-f23d-46a5-816e-841d2bcdfeb3.gif)
With `Kalpurush ANSI` ANSI font:
![Smart Quotes ANSI](https://user-images.githubusercontent.com/9459891/166911191-c21b62d9-8977-4983-b625-c1da148dc6bb.gif)

Option in Settngs to control the feature:
![image](https://user-images.githubusercontent.com/9459891/166911686-0711fd7b-aacd-431a-90ad-99585fccfcd7.png)

Closes #284