### PR TITLE
Replace qt5-default with qtbase5-dev

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -129,7 +129,7 @@ OpenBangla Keyboard currently has the following build dependencies:
 === Ubuntu & Debian derivatives
 On a Ubuntu/Debian system you can easily install them like this:
 ```bash
-sudo apt-get install build-essential rustc cargo cmake libibus-1.0-dev qtbase5-dev qt5-qmake libzstd-dev
+sudo apt-get install build-essential rustc cargo cmake libibus-1.0-dev qtbase5-dev qtbase5-dev-tools libzstd-dev
 ```
 
 === Fedora

--- a/README.adoc
+++ b/README.adoc
@@ -129,7 +129,7 @@ OpenBangla Keyboard currently has the following build dependencies:
 === Ubuntu & Debian derivatives
 On a Ubuntu/Debian system you can easily install them like this:
 ```bash
-sudo apt-get install build-essential rustc cargo cmake libibus-1.0-dev qt5-default libzstd-dev
+sudo apt-get install build-essential rustc cargo cmake libibus-1.0-dev qtbase5-dev qt5-qmake libzstd-dev
 ```
 
 === Fedora


### PR DESCRIPTION
Apt on Ubuntu now returns error saying the qt5-default package has no installation candidate. Instead we can use qtbase5-dev package as it is officially available on the repository. Also it is recommended from KDE community to not use the qt5-default package as a build dependency and to use qtbase5-dev instead. I also added the qt5-qmake package as the project uses qmake to generate makefiles.