### PR TITLE
Build packages for ibus and fcitx in Github Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,9 +11,7 @@ on:
 jobs:
   build:
     if: contains(github.event.head_commit.message, 'deploy+') == false
-    # Ubuntu latest image (20.04) doesn't have fcitx 5.0.5 development library which we require.
-    # So we have to run our CI under Ubuntu 22.04 image.
-    runs-on: "ubuntu-22.04"
+    runs-on: "ubuntu-latest"
     strategy:
       matrix:
         env:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         # container: [ "ubuntu:18.04", "ubuntu:20.04", "ubuntu:22.04", "ubuntu:23.04", "debian:11", "fedora:37", "fedora:38", "archlinux:latest" ]
-        container: [ "ubuntu:18.04", "ubuntu:20.04", "ubuntu:22.04", "ubuntu:23.04", "debian:11" ]
+        container: [ "ubuntu:18.04", "ubuntu:20.04", "ubuntu:22.04", "ubuntu:23.04", "debian:11", "fedora:37", "fedora:38" ]
         # this list should be updated from time to time by consulting these pages:
         # https://releases.ubuntu.com/
         # https://wiki.debian.org/DebianReleases#Production_Releases

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,7 +6,6 @@ on:
     tags-ignore: [ '**' ]
 
 jobs:
-
   build:
     if: contains(github.event.head_commit.message, 'deploy+') || contains(github.event.head_commit.message, 'pkg+')
     strategy:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,8 +18,10 @@ jobs:
         # https://fedoraproject.org/wiki/Releases
         ime: [ "ibus", "fcitx" ]
         exclude:
-          - ime: "fcitx"
-            container: [ "ubuntu:18.04", "ubuntu:20.04" ]
+          - container: "ubuntu:18.04"
+            ime: "fcitx"
+          - container: "ubuntu:20.04"
+            ime: "fcitx"
     runs-on: "ubuntu-latest"
     container:
       image: ${{ matrix.container }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,16 +11,19 @@ jobs:
     if: contains(github.event.head_commit.message, 'deploy+') || contains(github.event.head_commit.message, 'pkg+')
     strategy:
       matrix:
-        container: [ "ubuntu:18.04", "ubuntu:20.04", "ubuntu:22.04", "ubuntu:23.04", "debian:11", "fedora:37", "fedora:38", "archlinux:latest" ]
+        # container: [ "ubuntu:18.04", "ubuntu:20.04", "ubuntu:22.04", "ubuntu:23.04", "debian:11", "fedora:37", "fedora:38", "archlinux:latest" ]
+        container: [ "ubuntu:18.04", "ubuntu:20.04", "ubuntu:22.04", "ubuntu:23.04", "debian:11" ]
         # this list should be updated from time to time by consulting these pages:
         # https://releases.ubuntu.com/
         # https://wiki.debian.org/DebianReleases#Production_Releases
         # https://fedoraproject.org/wiki/Releases
+        ime: [ "ibus", "fcitx" ]
     runs-on: "ubuntu-latest"
     container:
       image: ${{ matrix.container }}
       env:
         DIST: ${{ matrix.container }}
+        IME: ${{ matrix.ime }}
         DEBIAN_FRONTEND: noninteractive
     steps:
       - name: checkout-source

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,6 +17,7 @@ jobs:
         # https://wiki.debian.org/DebianReleases#Production_Releases
         # https://fedoraproject.org/wiki/Releases
         ime: [ "ibus", "fcitx" ]
+        # Some distributions doesn't have the required version of fcitx library, so we exclude them.
         exclude:
           - container: "ubuntu:18.04"
             ime: "fcitx"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,6 +17,9 @@ jobs:
         # https://wiki.debian.org/DebianReleases#Production_Releases
         # https://fedoraproject.org/wiki/Releases
         ime: [ "ibus", "fcitx" ]
+        exclude:
+          - ime: "fcitx"
+            container: [ "ubuntu:18.04", "ubuntu:20.04" ]
     runs-on: "ubuntu-latest"
     container:
       image: ${{ matrix.container }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,8 @@ find_package(Qt5Core REQUIRED)
 find_package(Qt5Widgets REQUIRED)
 find_package(Qt5Network REQUIRED)
 
+message(STATUS "Qt5 framework version: ${Qt5Core_VERSION}")
+
 # Get system information. WIN32 and APPLE are defined by CMake
 if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
     set(OS_LINUX 1)

--- a/src/frontend/main.cpp
+++ b/src/frontend/main.cpp
@@ -25,7 +25,7 @@
 #include "Settings.h"
 
 int main(int argc, char *argv[]) {
-  if(qEnvironmentVariable("XDG_SESSION_TYPE") == "wayland") {
+  if(qgetenv("XDG_SESSION_TYPE") == "wayland") {
     // Use xcb backend under wayland to make the topbar movable.
     // TODO: Try out QWindow::startSystemMove() when we can depend on Qt 5.15
     // https://doc.qt.io/qt-5/qwindow.html#startSystemMove

--- a/tools/build.sh
+++ b/tools/build.sh
@@ -5,14 +5,12 @@ RELEASE_STUB="OpenBangla-Keyboard_${RELEASE_VERSION}-${IME}-"
 
 makeDeb () {
     RELEASE_FILENAME="${RELEASE_STUB}${DIST}.deb"
-    apt-get -y install build-essential pkg-config cmake libzstd-dev ninja-build curl qtbase5-dev qtchooser qt5-qmake qtbase5-dev-tools file
+    apt-get -y install build-essential pkg-config libibus-1.0-dev libfcitx5core-dev cmake libzstd-dev ninja-build curl qtbase5-dev qtchooser qt5-qmake qtbase5-dev-tools file
     curl https://sh.rustup.rs -sSf | sh -s -- -y --profile minimal --default-toolchain stable
     
     if [[ "${IME}" == "ibus" ]]; then
-        apt-get -y install libibus-1.0-dev
         cmake -H"$GITHUB_WORKSPACE" -B/build -GNinja -DENABLE_IBUS=ON -DCPACK_GENERATOR=DEB
     else
-        apt-get -y install libfcitx5core-dev
         cmake -H"$GITHUB_WORKSPACE" -B/build -GNinja -DENABLE_FCITX=ON -DCPACK_GENERATOR=DEB
     fi
 
@@ -22,9 +20,15 @@ makeDeb () {
 
 makeRpm () {
     RELEASE_FILENAME="${RELEASE_STUB}${DIST}.rpm"
-    dnf install -y --allowerasing @buildsys-build cmake ibus-devel libzstd-devel qt5-qtdeclarative-devel ninja-build curl
+    dnf install -y --allowerasing @buildsys-build cmake ibus-devel fcitx5-devel libzstd-devel qt5-qtdeclarative-devel ninja-build curl
     curl https://sh.rustup.rs -sSf | sh -s -- -y --profile minimal --default-toolchain stable
-    cmake -H"$GITHUB_WORKSPACE" -B/build -GNinja -DCPACK_GENERATOR=RPM
+    
+    if [[ "${IME}" == "ibus" ]]; then
+        cmake -H"$GITHUB_WORKSPACE" -B/build -GNinja -DENABLE_IBUS=ON -DCPACK_GENERATOR=RPM
+    else
+        cmake -H"$GITHUB_WORKSPACE" -B/build -GNinja -DENABLE_FCITX=ON -DCPACK_GENERATOR=RPM
+    fi
+    
     ninja package -C /build
     RELEASE_FILE="/build/${RELEASE_FILENAME}"
 }

--- a/tools/build.sh
+++ b/tools/build.sh
@@ -5,12 +5,13 @@ RELEASE_STUB="OpenBangla-Keyboard_${RELEASE_VERSION}-${IME}-"
 
 makeDeb () {
     RELEASE_FILENAME="${RELEASE_STUB}${DIST}.deb"
-    apt-get -y install build-essential pkg-config libibus-1.0-dev libfcitx5core-dev cmake libzstd-dev ninja-build curl qtbase5-dev qtchooser qt5-qmake qtbase5-dev-tools file
+    apt-get -y install build-essential pkg-config libibus-1.0-dev cmake libzstd-dev ninja-build curl qtbase5-dev qtchooser qt5-qmake qtbase5-dev-tools file
     curl https://sh.rustup.rs -sSf | sh -s -- -y --profile minimal --default-toolchain stable
     
     if [[ "${IME}" == "ibus" ]]; then
         cmake -H"$GITHUB_WORKSPACE" -B/build -GNinja -DENABLE_IBUS=ON -DCPACK_GENERATOR=DEB
     else
+        apt-get -y install libfcitx5core-dev
         cmake -H"$GITHUB_WORKSPACE" -B/build -GNinja -DENABLE_FCITX=ON -DCPACK_GENERATOR=DEB
     fi
 
@@ -28,7 +29,7 @@ makeRpm () {
     else
         cmake -H"$GITHUB_WORKSPACE" -B/build -GNinja -DENABLE_FCITX=ON -DCPACK_GENERATOR=RPM
     fi
-    
+
     ninja package -C /build
     RELEASE_FILE="/build/${RELEASE_FILENAME}"
 }

--- a/tools/build.sh
+++ b/tools/build.sh
@@ -5,7 +5,7 @@ RELEASE_STUB="OpenBangla-Keyboard_${RELEASE_VERSION}-${IME}-"
 
 makeDeb () {
     RELEASE_FILENAME="${RELEASE_STUB}${DIST}.deb"
-    apt-get -y install build-essential cmake libzstd-dev ninja-build curl qtbase5-dev qtchooser qt5-qmake qtbase5-dev-tools file
+    apt-get -y install build-essential pkg-config cmake libzstd-dev ninja-build curl qtbase5-dev qtchooser qt5-qmake qtbase5-dev-tools file
     curl https://sh.rustup.rs -sSf | sh -s -- -y --profile minimal --default-toolchain stable
     
     if [[ "${IME}" == "ibus" ]]; then

--- a/tools/build.sh
+++ b/tools/build.sh
@@ -1,13 +1,21 @@
 #! /bin/bash
 RELEASE_VERSION=$(cat version.txt | head -n1)
 # follow cmake PACKAGE_FILE_NAME directive in main repo
-RELEASE_STUB="OpenBangla-Keyboard_${RELEASE_VERSION}-"
+RELEASE_STUB="OpenBangla-Keyboard_${RELEASE_VERSION}-${IME}-"
 
 makeDeb () {
     RELEASE_FILENAME="${RELEASE_STUB}${DIST}.deb"
-    apt-get -y install build-essential cmake libibus-1.0-dev libzstd-dev ninja-build curl qtbase5-dev qtchooser qt5-qmake qtbase5-dev-tools file
+    apt-get -y install build-essential cmake libzstd-dev ninja-build curl qtbase5-dev qtchooser qt5-qmake qtbase5-dev-tools file
     curl https://sh.rustup.rs -sSf | sh -s -- -y --profile minimal --default-toolchain stable
-    cmake -H"$GITHUB_WORKSPACE" -B/build -GNinja -DCPACK_GENERATOR=DEB
+    
+    if [[ "${IME}" == "ibus" ]]; then
+        apt-get -y install libibus-1.0-dev
+        cmake -H"$GITHUB_WORKSPACE" -B/build -GNinja -DENABLE_IBUS=ON -DCPACK_GENERATOR=DEB
+    else
+        apt-get -y install libfcitx5core-dev
+        cmake -H"$GITHUB_WORKSPACE" -B/build -GNinja -DENABLE_FCITX=ON -DCPACK_GENERATOR=DEB
+    fi
+
     ninja package -C /build
     RELEASE_FILE="/build/${RELEASE_FILENAME}"
 }

--- a/tools/build.sh
+++ b/tools/build.sh
@@ -5,7 +5,7 @@ RELEASE_STUB="OpenBangla-Keyboard_${RELEASE_VERSION}-${IME}-"
 
 makeDeb () {
     RELEASE_FILENAME="${RELEASE_STUB}${DIST}.deb"
-    apt-get -y install build-essential pkg-config libibus-1.0-dev cmake libzstd-dev ninja-build curl qtbase5-dev qtchooser qt5-qmake qtbase5-dev-tools file
+    apt-get -y install build-essential pkg-config libibus-1.0-dev cmake libzstd-dev ninja-build curl qtbase5-dev qtbase5-dev-tools file
     curl https://sh.rustup.rs -sSf | sh -s -- -y --profile minimal --default-toolchain stable
     
     if [[ "${IME}" == "ibus" ]]; then


### PR DESCRIPTION
This PR implements package building for ibus and fcitx5 backends for Debian, Ubuntu, and Fedora distributions. However, for Archlinux, it is not implemented.

* `qEnvironmentVariable` is available from Qt 5.10, so use the alternative `qgetenv` function.
* Print the Qt5 framework version while CMake runs.
* Use the `ubuntu-latest` image, which now contains the fcitx 5.0.5 development library.