### PR TITLE
Preserve user's selection if the keypress was a punctuation mark

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * ANSI encoding support ([#33])
 * Smart Quoting feature ([#35])
 * Whole word deletion by <kbd>Ctrl</kbd> + <kbd>Backspace</kbd> keypress combination feature ([#36])
+* Preserve user's candidate selection if the keypress was a punctuation mark in Phonetic Method ([#363])
 * Old style typing in Fixed method ([#20])
 * Inclusion of typed English word in Fixed method suggestions.
 * Introduce System tray entry for TopBar ([#209])
@@ -33,6 +34,8 @@
 [#300]: https://github.com/OpenBangla/OpenBangla-Keyboard/pull/300
 [#313]: https://github.com/OpenBangla/OpenBangla-Keyboard/pull/313
 [#355]: https://github.com/OpenBangla/OpenBangla-Keyboard/pull/355
+[#363]: https://github.com/OpenBangla/OpenBangla-Keyboard/pull/363
+
 ## 2.0.0
 * Complete re-implementation of input method functionalities in Rust. ([#107][107]) It is [~1.2x faster in searching][3] dictionary suggestions.
 * Dictionary suggestion is now available in Fixed Method Layouts(Provat, National etc.) ([#61][61], [#6][6])

--- a/src/engine/fcitx/openbangla.cpp
+++ b/src/engine/fcitx/openbangla.cpp
@@ -332,8 +332,18 @@ public:
     if ((ctrlKey && altKey) || altGrPressed_) {
       modifier |= MODIFIER_ALT_GR;
     }
+   
+    auto index = 0;
 
-    suggestion_.reset(riti_get_suggestion_for_key(ctx, ritiKey, modifier));
+    if (riti_context_ongoing_input_session(ctx) && !riti_suggestion_is_lonely(suggestion_.get())) {
+      auto candidateList = std::dynamic_pointer_cast<CommonCandidateList>(ic_->inputPanel().candidateList());
+      auto idx = candidateList->globalCursorIndex();
+      if (idx >= 0 && idx < candidateList->totalSize()) {
+        index = idx;
+      }
+    }
+
+    suggestion_.reset(riti_get_suggestion_for_key(ctx, ritiKey, modifier, index));
 
     if (!riti_suggestion_is_empty(suggestion_.get())) {
       updateUI();

--- a/src/engine/ibus/main.cpp
+++ b/src/engine/ibus/main.cpp
@@ -249,7 +249,13 @@ gboolean engine_process_key(guint keyval, guint keycode, guint state) {
     modifier |= MODIFIER_ALT_GR;
   }
 
-  suggestion = riti_get_suggestion_for_key(ctx, key, modifier);
+  int index = 0;
+
+  if (riti_context_ongoing_input_session(ctx) && !riti_suggestion_is_lonely(suggestion)) {
+    index = ibus_lookup_table_get_cursor_pos(table);
+  }
+
+  suggestion = riti_get_suggestion_for_key(ctx, key, modifier, index);
 
   if(!riti_suggestion_is_empty(suggestion)) {
     engine_update_lookup_table();


### PR DESCRIPTION
In phonetic method, preserve user's candidate selection if the keypress was a punctuation mark.

![preserve_selection](https://github.com/OpenBangla/OpenBangla-Keyboard/assets/9459891/c5a9f0d1-e368-45f2-98e6-22c742222e9c)

Implements #361 

cc @larina3315