### PR TITLE
Use the CMAKE_INSTALL_PREFIX instead of hardcoded /usr/share for loading data

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,8 +53,6 @@ if(OS_LINUX)
     # Generate compile_commands.json to satisfy vscode linux configuration
     set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
-    ## Set Directories for installing and storing files
-    set(CMAKE_INSTALL_PREFIX "/usr")
     if(NOT DEFINED BIN_DIR)
         set(BIN_DIR "${CMAKE_INSTALL_PREFIX}/bin")
     endif()

--- a/src/engine/fcitx/openbangla.cpp
+++ b/src/engine/fcitx/openbangla.cpp
@@ -442,7 +442,7 @@ void OpenBanglaEngine::populateConfig(const RawConfig &config) {
   riti_config_set_suggestion_include_english(cfg_.get(), includeEnglish);
   riti_config_set_phonetic_suggestion(cfg_.get(), showCWPhonetic);
   riti_config_set_database_dir(cfg_.get(),
-                               "/usr/share/openbangla-keyboard/data");
+                               PROJECT_DATADIR "/data");
   riti_config_set_fixed_suggestion(cfg_.get(), showPrevWinFixed);
   riti_config_set_fixed_auto_vowel(cfg_.get(), autoVowelFormFixed);
   riti_config_set_fixed_auto_chandra(cfg_.get(), autoChandraPosFixed);

--- a/src/shared/FileSystem.cpp
+++ b/src/shared/FileSystem.cpp
@@ -19,31 +19,31 @@
 #include "FileSystem.h"
 
 QString LayoutsFilePath() {
-    return "/usr/share/openbangla-keyboard/layouts";
+    return PROJECT_DATADIR "/layouts";
 }
 
 QString AvroPhoneticLayoutPath() {
-    return "/usr/share/openbangla-keyboard/layouts/avrophonetic.json";
+    return PROJECT_DATADIR "/layouts/avrophonetic.json";
 }
 
 QString DatabasePath() {
-    return "/usr/share/openbangla-keyboard/data";
+    return PROJECT_DATADIR "/data";
 }
 
 QString DictionaryPath() {
-    return "/usr/share/openbangla-keyboard/data/dictionary.json";
+    return PROJECT_DATADIR "/data/dictionary.json";
 }
 
 QString SuffixDictPath() {
-    return "/usr/share/openbangla-keyboard/data/suffix.json";
+    return PROJECT_DATADIR "/data/suffix.json";
 }
 
 QString RegexDictPath() {
-    return "/usr/share/openbangla-keyboard/data/regex.json";
+    return PROJECT_DATADIR "/data/regex.json";
 }
 
 QString AutoCorrectFilePath() {
-    return "/usr/share/openbangla-keyboard/data/autocorrect.json";
+    return PROJECT_DATADIR "/data/autocorrect.json";
 }
 
 QString environmentVariable(const char *varName, const QString &defaultValue)


### PR DESCRIPTION
This would be required for flatpak / nixos to work without patch.

Also bsd system uses /usr/local instead of /usr by default.