### PR TITLE
Implement boxed styling for windows and the top bar

### DIFF
--- a/src/frontend/AboutDialog.ui
+++ b/src/frontend/AboutDialog.ui
@@ -17,7 +17,7 @@
    <string notr="true">QDialog {
     background: #18181b;
     border: 1px solid rgba(255, 255, 255, 0.1);
-    border-radius: 16px;
+    border-radius: 0px;
 }
 
 QLabel {

--- a/src/frontend/AboutFile.ui
+++ b/src/frontend/AboutFile.ui
@@ -17,7 +17,7 @@
    <string notr="true">QDialog {
     background: #18181b;
     border: 1px solid rgba(255, 255, 255, 0.1);
-    border-radius: 12px;
+    border-radius: 0px;
 }
 
 QLabel {

--- a/src/frontend/AutoCorrectDialog.ui
+++ b/src/frontend/AutoCorrectDialog.ui
@@ -17,7 +17,7 @@
    <string notr="true">QDialog {
     background: #18181b;
     border: 1px solid rgba(255, 255, 255, 0.1);
-    border-radius: 12px;
+    border-radius: 0px;
 }
 
 QLabel {

--- a/src/frontend/LayoutViewer.ui
+++ b/src/frontend/LayoutViewer.ui
@@ -17,7 +17,7 @@
    <string notr="true">QDialog {
     background: #18181b;
     border: 1px solid rgba(255, 255, 255, 0.1);
-    border-radius: 12px;
+    border-radius: 0px;
 }
 
 QPushButton {

--- a/src/frontend/SettingsDialog.ui
+++ b/src/frontend/SettingsDialog.ui
@@ -23,7 +23,7 @@
    <string notr="true">QDialog {
     background: #0f0f0f;
     border: 1px solid rgba(255, 255, 255, 0.1);
-    border-radius: 8px;
+    border-radius: 0px;
 }
 
 QGroupBox {

--- a/src/frontend/TopBar.ui
+++ b/src/frontend/TopBar.ui
@@ -26,13 +26,13 @@
    <string notr="true">QMainWindow {
     background-color: #000000;
     border: 1px solid rgba(255, 255, 255, 0.1);
-    border-radius: 10px;
+    border-radius: 0px;
 }
 
 QPushButton {
     background: transparent;
     border: none;
-    border-radius: 10px;
+    border-radius: 0px;
     padding: 12px;
     margin: 2px;
     color: rgba(0, 0, 0, 0.7);
@@ -50,22 +50,22 @@ QPushButton:pressed {
 QPushButton#buttonSetLayout:checked {
     background: rgba(14, 165, 233, 0.15);
     border: 1px solid rgba(14, 165, 233, 0.2);
-    border-radius: 10px;
+    border-radius: 0px;
 }
 
 QPushButton#buttonShutdown:hover {
     background: rgba(255, 0, 0, 0.55);
-    border-radius: 10px;
+    border-radius: 0px;
 }
 QWidget#centralwidget {
     background-color: #000000;
-    border-radius: 10px;
+    border-radius: 0px;
 }
 QToolTip {
     background: #0f0f0f;
     color: rgba(255, 255, 255, 0.9);
     border: 1px solid rgba(255, 255, 255, 0.1);
-    border-radius: 10px;
+    border-radius: 0px;
     padding: 8px 12px;
 }</string>
   </property>


### PR DESCRIPTION
### Description
My initial focus was on fixing the window borders. Then, I observed that the top bar and its submenu looked out of place with their existing style. To ensure a more cohesive appearance, I've also applied a boxed shape to those components.

### Screenshot
![Screenshot_20250501_161013](https://github.com/user-attachments/assets/4eda20e8-7970-4f94-b09e-da690168c2fc)

Fixes: #406 

