### PR TITLE
Bangla Emojis :heart_eyes:  and faster suggestions! :rocket:  :tada: 

### DIFF
--- a/src/engine/fcitx/openbangla.cpp
+++ b/src/engine/fcitx/openbangla.cpp
@@ -439,11 +439,19 @@ void OpenBanglaEngine::populateConfig(const RawConfig &config) {
   const bool smartQuoting =
       booleanValue(config, "settings/SmartQuoting", true);
 
-  riti_config_set_layout_file(cfg_.get(), layoutPath.data());
+  if(!riti_config_set_layout_file(cfg_.get(), layoutPath.data())) {
+    FCITX_OPENBANGLA_DEBUG() << "Failed to set layout file: " << layoutPath;
+  }
+  
   riti_config_set_suggestion_include_english(cfg_.get(), includeEnglish);
   riti_config_set_phonetic_suggestion(cfg_.get(), showCWPhonetic);
-  riti_config_set_database_dir(cfg_.get(),
-                               PROJECT_DATADIR "/data");
+
+  if(!riti_config_set_database_dir(cfg_.get(),
+                               PROJECT_DATADIR "/data")) {
+    FCITX_OPENBANGLA_DEBUG() << "Failed to set database directory: "
+                             << PROJECT_DATADIR << "/data";
+  }
+
   riti_config_set_fixed_suggestion(cfg_.get(), showPrevWinFixed);
   riti_config_set_fixed_auto_vowel(cfg_.get(), autoVowelFormFixed);
   riti_config_set_fixed_auto_chandra(cfg_.get(), autoChandraPosFixed);

--- a/src/engine/ibus/main.cpp
+++ b/src/engine/ibus/main.cpp
@@ -17,10 +17,17 @@ static Suggestion *suggestion = nullptr;
 static bool altGr = false;
 
 void update_with_settings() {
-  riti_config_set_layout_file(config, gSettings->getLayoutPath().toStdString().data());
+  if(!riti_config_set_layout_file(config, gSettings->getLayoutPath().toStdString().data())) {
+    LOG_ERROR("[IM:iBus]: Failed to set layout file: %s\n", gSettings->getLayoutPath().toStdString().data());
+  }
+
   riti_config_set_suggestion_include_english(config, gSettings->getSuggestionIncludeEnglish());
   riti_config_set_phonetic_suggestion(config, gSettings->getShowCWPhonetic());
-  riti_config_set_database_dir(config, DatabasePath().toStdString().data());
+
+  if(!riti_config_set_database_dir(config, DatabasePath().toStdString().data())) {
+    LOG_ERROR("[IM:iBus]: Failed to set database directory: %s\n", DatabasePath().toStdString().data());
+  }
+  
   riti_config_set_fixed_suggestion(config, gSettings->getShowPrevWinFixed());
   riti_config_set_fixed_auto_vowel(config, gSettings->getAutoVowelFormFixed());
   riti_config_set_fixed_auto_chandra(config, gSettings->getAutoChandraPosFixed());


### PR DESCRIPTION
https://github.com/user-attachments/assets/102c19b9-041d-495e-90bd-f039a47b7307

Bangla emojis are now implemented and the suggestion generation is faster than ever! OpenBangla Keyboard now uses [`upodesh`](https://github.com/OpenBangla/upodesh) through [`riti`](https://github.com/OpenBangla/riti) which enables this faster generation of suggestions and provided the needed time to search Emojis based on the Bangla words without regressing performance.