### PR TITLE
Update Ubuntu version handling in installer script

### DIFF
--- a/tools/install.sh
+++ b/tools/install.sh
@@ -60,7 +60,7 @@ case $DISTRO_NAME in
    	VERSION_ID=$(grep DISTRIB_RELEASE /etc/upstream-release/lsb-release|cut -d= -f2)
   fi
 	  case ${VERSION_ID%%.*} in
-	  	24|23|22|21|20|18) VERSION_ID=${VERSION_ID%%.*}.04;UBUNTU_SUPPORTED=1;;
+	  	25|24|23|22|21|20|18) VERSION_ID=${VERSION_ID%%.*}.04;UBUNTU_SUPPORTED=1;;
 	  	*) echo "This Ubuntu release \"$VERSION_ID\" is too young or too old for me to handle";exit 1;;
 	  esac
   if [[ $UBUNTU_SUPPORTED = 1 ]]; then


### PR DESCRIPTION
This pull request updates the `tools/install.sh` script to add support for Ubuntu 25.x releases. The change ensures that the installation script recognizes Ubuntu 25 as a supported version, alongside previous versions.

* Install script update:
  * Modified the supported Ubuntu versions in the `tools/install.sh` script to include version 25, allowing the script to run on Ubuntu 25.x systems.