### PR TITLE
Add official aarch64 release builds to deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,7 +12,7 @@ jobs:
       matrix:
         platform: [ "ubuntu-latest", "ubuntu-24.04-arm" ]
         # container: [ "ubuntu:18.04", "ubuntu:20.04", "ubuntu:22.04", "ubuntu:23.04", "debian:11", "fedora:37", "fedora:38", "archlinux:latest" ]
-        container: [ "ubuntu:20.04", "ubuntu:22.04", "ubuntu:24.04", "debian:11", "debian:12", "fedora:40", "fedora:41", "opensuse/tumbleweed" ]
+        container: [ "ubuntu:22.04", "ubuntu:24.04", "debian:12", "fedora:40", "fedora:41", "opensuse/tumbleweed" ]
         # this list should be updated from time to time by consulting these pages:
         # https://releases.ubuntu.com/
         # https://wiki.debian.org/DebianReleases#Production_Releases

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,7 +12,7 @@ jobs:
       matrix:
         platform: [ "ubuntu-latest", "ubuntu-24.04-arm" ]
         # container: [ "ubuntu:18.04", "ubuntu:20.04", "ubuntu:22.04", "ubuntu:23.04", "debian:11", "fedora:37", "fedora:38", "archlinux:latest" ]
-        container: [ "ubuntu:22.04", "ubuntu:24.04", "debian:12", "fedora:40", "fedora:41", "opensuse/tumbleweed" ]
+        container: [ "ubuntu:22.04", "ubuntu:24.04", "debian:12", "fedora:40", "fedora:41" ]
         # this list should be updated from time to time by consulting these pages:
         # https://releases.ubuntu.com/
         # https://wiki.debian.org/DebianReleases#Production_Releases
@@ -23,8 +23,6 @@ jobs:
         exclude:
           - container: "ubuntu:20.04"
             ime: "fcitx"
-          - platform: "ubuntu-24.04-arm"
-            container: "opensuse/tumbleweed"
     runs-on: ${{ matrix.platform }}
     container:
       image: ${{ matrix.platform == 'ubuntu-24.04-arm' && format('arm64v8/{0}', matrix.container) || matrix.container }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,8 +23,6 @@ jobs:
         exclude:
           - container: "ubuntu:20.04"
             ime: "fcitx"
-          - platform: "ubuntu-24.04-arm"
-            container: "opensuse/tumbleweed"
     runs-on: ${{ matrix.platform }}
     container:
       image: ${{ matrix.container }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,9 +20,6 @@ jobs:
         # https://en.wikipedia.org/wiki/OpenSUSE#Version_history
         ime: [ "ibus", "fcitx" ]
         # Some distributions doesn't have the required version of fcitx library, so we exclude them.
-        exclude:
-          - container: "ubuntu:20.04"
-            ime: "fcitx"
     runs-on: ${{ matrix.platform }}
     container:
       image: ${{ matrix.container }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,7 +12,7 @@ jobs:
       matrix:
         platform: [ "ubuntu-latest", "ubuntu-24.04-arm" ]
         # container: [ "ubuntu:18.04", "ubuntu:20.04", "ubuntu:22.04", "ubuntu:23.04", "debian:11", "fedora:37", "fedora:38", "archlinux:latest" ]
-        container: [ "ubuntu:22.04", "ubuntu:24.04", "debian:12", "fedora:40", "fedora:41" ]
+        container: [ "ubuntu:22.04", "ubuntu:24.04", "debian:12", "fedora:40", "fedora:41", "opensuse/tumbleweed" ]
         # this list should be updated from time to time by consulting these pages:
         # https://releases.ubuntu.com/
         # https://wiki.debian.org/DebianReleases#Production_Releases
@@ -23,6 +23,8 @@ jobs:
         exclude:
           - container: "ubuntu:20.04"
             ime: "fcitx"
+          - platform: "ubuntu-24.04-arm"
+            container: "opensuse/tumbleweed"
     runs-on: ${{ matrix.platform }}
     container:
       image: ${{ matrix.container }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,7 +25,7 @@ jobs:
             ime: "fcitx"
     runs-on: ${{ matrix.platform }}
     container:
-      image: ${{ matrix.platform == 'ubuntu-24.04-arm' && format('arm64v8/{0}', matrix.container) || matrix.container }}
+      image: ${{ matrix.container }}
       env:
         DIST: ${{ matrix.container }}
         IME: ${{ matrix.ime }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,7 +6,7 @@ on:
     tags-ignore: [ '**' ]
 
 jobs:
-  build:
+  build-x64:
     if: contains(github.event.head_commit.message, 'deploy+') || contains(github.event.head_commit.message, 'pkg+')
     strategy:
       matrix:
@@ -64,12 +64,68 @@ jobs:
       - name: upload-artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: pkg-${{ steps.sanitizer.outputs.sanitized_container }}-${{ matrix.ime }}
+          name: pkg-x64-${{ steps.sanitizer.outputs.sanitized_container }}-${{ matrix.ime }}
+          path: artifact
+
+  build-arm64:
+    if: contains(github.event.head_commit.message, 'deploy+') || contains(github.event.head_commit.message, 'pkg+')
+    strategy:
+      matrix:
+        # Note: opensuse doesn't have official arm64v8 images on Docker Hub
+        container: [ "ubuntu:20.04", "ubuntu:22.04", "ubuntu:24.04", "debian:11", "debian:12", "fedora:40", "fedora:41" ]
+        ime: [ "ibus", "fcitx" ]
+        # Some distributions doesn't have the required version of fcitx library, so we exclude them.
+        exclude:
+          - container: "ubuntu:20.04"
+            ime: "fcitx"
+    runs-on: "ubuntu-24.04-arm"
+    container:
+      image: arm64v8/${{ matrix.container }}
+      env:
+        DIST: ${{ matrix.container }}
+        IME: ${{ matrix.ime }}
+        DEBIAN_FRONTEND: noninteractive
+    steps:
+      - name: install-git
+        run: |
+          # Install Git based on distro
+          if command -v apt-get >/dev/null; then
+            apt-get update -y
+            apt-get install -y git
+          elif command -v dnf >/dev/null; then
+            dnf install -y git
+          elif command -v zypper >/dev/null; then
+            zypper install -y git
+          elif command -v pacman >/dev/null; then
+            pacman -Sy git --noconfirm
+          fi
+      
+      - name: checkout-source
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: run-builder
+        shell: bash
+        run: ./tools/build.sh
+
+      - name: Sanitize container name
+        id: sanitizer
+        shell: bash
+        run: |
+          # Replace colons and slashes with dashes
+          SANITIZED_CONTAINER=$(echo "${{ matrix.container }}" | sed 's/[:\\/]/-/g')
+          echo "sanitized_container=$SANITIZED_CONTAINER" >> $GITHUB_OUTPUT
+
+      - name: upload-artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: pkg-arm64-${{ steps.sanitizer.outputs.sanitized_container }}-${{ matrix.ime }}
           path: artifact
 
   release:
     if: contains(github.event.head_commit.message, 'deploy+')
-    needs: build
+    needs: [build-x64, build-arm64]
     runs-on: "ubuntu-latest"
     steps:
       - name: checkout-source

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,10 +6,11 @@ on:
     tags-ignore: [ '**' ]
 
 jobs:
-  build-x64:
+  build:
     if: contains(github.event.head_commit.message, 'deploy+') || contains(github.event.head_commit.message, 'pkg+')
     strategy:
       matrix:
+        platform: [ "ubuntu-latest", "ubuntu-24.04-arm" ]
         # container: [ "ubuntu:18.04", "ubuntu:20.04", "ubuntu:22.04", "ubuntu:23.04", "debian:11", "fedora:37", "fedora:38", "archlinux:latest" ]
         container: [ "ubuntu:20.04", "ubuntu:22.04", "ubuntu:24.04", "debian:11", "debian:12", "fedora:40", "fedora:41", "opensuse/tumbleweed" ]
         # this list should be updated from time to time by consulting these pages:
@@ -22,9 +23,11 @@ jobs:
         exclude:
           - container: "ubuntu:20.04"
             ime: "fcitx"
-    runs-on: "ubuntu-latest"
+          - platform: "ubuntu-24.04-arm"
+            container: "opensuse/tumbleweed"
+    runs-on: ${{ matrix.platform }}
     container:
-      image: ${{ matrix.container }}
+      image: ${{ matrix.platform == 'ubuntu-24.04-arm' && format('arm64v8/{0}', matrix.container) || matrix.container }}
       env:
         DIST: ${{ matrix.container }}
         IME: ${{ matrix.ime }}
@@ -64,68 +67,12 @@ jobs:
       - name: upload-artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: pkg-x64-${{ steps.sanitizer.outputs.sanitized_container }}-${{ matrix.ime }}
-          path: artifact
-
-  build-arm64:
-    if: contains(github.event.head_commit.message, 'deploy+') || contains(github.event.head_commit.message, 'pkg+')
-    strategy:
-      matrix:
-        # Note: opensuse doesn't have official arm64v8 images on Docker Hub
-        container: [ "ubuntu:20.04", "ubuntu:22.04", "ubuntu:24.04", "debian:11", "debian:12", "fedora:40", "fedora:41" ]
-        ime: [ "ibus", "fcitx" ]
-        # Some distributions doesn't have the required version of fcitx library, so we exclude them.
-        exclude:
-          - container: "ubuntu:20.04"
-            ime: "fcitx"
-    runs-on: "ubuntu-24.04-arm"
-    container:
-      image: arm64v8/${{ matrix.container }}
-      env:
-        DIST: ${{ matrix.container }}
-        IME: ${{ matrix.ime }}
-        DEBIAN_FRONTEND: noninteractive
-    steps:
-      - name: install-git
-        run: |
-          # Install Git based on distro
-          if command -v apt-get >/dev/null; then
-            apt-get update -y
-            apt-get install -y git
-          elif command -v dnf >/dev/null; then
-            dnf install -y git
-          elif command -v zypper >/dev/null; then
-            zypper install -y git
-          elif command -v pacman >/dev/null; then
-            pacman -Sy git --noconfirm
-          fi
-      
-      - name: checkout-source
-        uses: actions/checkout@v4
-        with:
-          submodules: recursive
-
-      - name: run-builder
-        shell: bash
-        run: ./tools/build.sh
-
-      - name: Sanitize container name
-        id: sanitizer
-        shell: bash
-        run: |
-          # Replace colons and slashes with dashes
-          SANITIZED_CONTAINER=$(echo "${{ matrix.container }}" | sed 's/[:\\/]/-/g')
-          echo "sanitized_container=$SANITIZED_CONTAINER" >> $GITHUB_OUTPUT
-
-      - name: upload-artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: pkg-arm64-${{ steps.sanitizer.outputs.sanitized_container }}-${{ matrix.ime }}
+          name: pkg-${{ matrix.platform == 'ubuntu-24.04-arm' && 'arm64' || 'x64' }}-${{ steps.sanitizer.outputs.sanitized_container }}-${{ matrix.ime }}
           path: artifact
 
   release:
     if: contains(github.event.head_commit.message, 'deploy+')
-    needs: [build-x64, build-arm64]
+    needs: build
     runs-on: "ubuntu-latest"
     steps:
       - name: checkout-source

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -151,7 +151,6 @@ set(CPACK_RPM_EXCLUDE_FROM_AUTO_FILELIST_ADDITION "/usr/share/applications" "/us
                                                   "/usr/share/icons/hicolor/32x32" "/usr/share/icons/hicolor/32x32/apps"
                                                   "/usr/share/icons/hicolor/48x48" "/usr/share/icons/hicolor/48x48/apps"
                                                   "/usr/share/icons/hicolor/512x512" "/usr/share/icons/hicolor/512x512/apps")
-set(CPACK_PACKAGE_FILE_NAME "${CPACK_PACKAGE_NAME}_${PROJECT_VERSION}-$ENV{DIST}")
 # Configure CPack on the basis of which backend we are building for.
 if(ENABLE_IBUS)
     ## IBUS
@@ -182,5 +181,8 @@ elseif(APPLE)
     set(CPACK_PRODUCTBUILD_BACKGROUND_DARKAQUA "installer.png")
     set(CPACK_PRODUCTBUILD_BACKGROUND_DARKAQUA_ALIGNMENT "left")
 endif()
+
+# Set package filename after CPACK_PACKAGE_NAME is defined
+set(CPACK_PACKAGE_FILE_NAME "${CPACK_PACKAGE_NAME}_${PROJECT_VERSION}-$ENV{DIST}")
 
 include(CPack)

--- a/src/frontend/TopBar.cpp
+++ b/src/frontend/TopBar.cpp
@@ -379,12 +379,16 @@ bool TopBar::eventFilter(QObject *object, QEvent *event) {
             // Mouse release event was missed; stop dragging.
             canMoveTopbar = false;
             ui->buttonIcon->setCursor(Qt::ArrowCursor);
-        } else if(this->windowHandle()->startSystemMove()){
+        }
+#if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
+        else if(this->windowHandle()->startSystemMove()){
             // The window manager now owns the drag and will consume the
             // mouse release event, so reset our drag state immediately.
             canMoveTopbar = false;
             ui->buttonIcon->setCursor(Qt::ArrowCursor);
-        } else {
+        }
+#endif
+        else {
             ui->buttonIcon->setCursor(Qt::ClosedHandCursor);
             move(e->globalX() - pressedMouseX, e->globalY() - pressedMouseY);
         }

--- a/src/frontend/TopBar.cpp
+++ b/src/frontend/TopBar.cpp
@@ -379,16 +379,12 @@ bool TopBar::eventFilter(QObject *object, QEvent *event) {
             // Mouse release event was missed; stop dragging.
             canMoveTopbar = false;
             ui->buttonIcon->setCursor(Qt::ArrowCursor);
-        }
-#if QT_VERSION >= QT_VERSION_CHECK(5, 15, 0)
-        else if(this->windowHandle()->startSystemMove()){
+        } else if(this->windowHandle()->startSystemMove()){
             // The window manager now owns the drag and will consume the
             // mouse release event, so reset our drag state immediately.
             canMoveTopbar = false;
             ui->buttonIcon->setCursor(Qt::ArrowCursor);
-        }
-#endif
-        else {
+        } else {
             ui->buttonIcon->setCursor(Qt::ClosedHandCursor);
             move(e->globalX() - pressedMouseX, e->globalY() - pressedMouseY);
         }


### PR DESCRIPTION
This adds official aarch64 release builds to the deploy workflow so ARM64 users can download prebuilt artifacts instead of building from source.
I've split x86_64 and aarch64 into separate jobs.
I also had to add two commits to fix issues: one for broken package filenames caused by `CPACK_PACKAGE_FILE_NAME` being set before `CPACK_PACKAGE_NAME`, and one for a Qt 5.15+ API used on older Qt versions in CI. I am not very experienced in this area, so please review those two fixes. Please also provide feedback on if the code fits the style of this codebase (e.g. using macros to determine qt version).
The built packages can be seen [here in a workflow run](https://github.com/permafrost06/OpenBangla-Keyboard/actions/runs/25186932567).

EDIT: I've only tested the fedora 41 package on Fedora Asahi Remix (Apple M1)

Fixes #461
Fixes #408